### PR TITLE
release: v0.15.0 (CHANGELOG header fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ covers changes made since the fork.
 
 ## [Unreleased]
 
-## [0.14.0] - 2026-04-30
+## [0.15.0] - 2026-04-30
 
 Audit-driven maintenance cycle (see `~/opensnes_audit_2026-04-26.md` and
 `~/opensnes_remediation_plan_2026-04-26.md`). 19 of 23 plan items completed


### PR DESCRIPTION
## Release v0.15.0

Tiny follow-up to PR #35 (which was titled "release: v0.14.0" but
collided with the existing v0.14.0 tag from PR #33, published
2026-03-25 with assets). Bumps the CHANGELOG section header from
[0.14.0] to [0.15.0] so the next tag matches the documented version.

The full content was already merged in PR #35 — no change to code,
ROMs, or assets. Only this single line of CHANGELOG.

After merge, the release.yml guard will tag main's head as v0.15.0
and build the per-OS release zips against the same content already
validated under PR #35.