### PR TITLE
release: v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ covers changes made since the fork.
 
 ## [Unreleased]
 
+## [0.15.2] - 2026-05-01
+
+First of the three "framework opt-ins" promised by `PHILOSOPHY.md`
+(alongside the planned scene/state stack and the asset bundle
+convention). Ships an opt-in `gameloop` module that owns the
+`while (1) WaitForVBlank(); update();` cadence so user code can stay
+focused on its own logic.
+
+### Added
+
+- **`<snes/gameloop.h>` + `gameloop` library module (chantier D.1)** —
+  opt-in via `LIB_MODULES`, not auto-included by `<snes.h>`. Public
+  surface is one struct and one function:
+  ```c
+  typedef struct {
+      void (*init)(void);     // optional, NULL to skip
+      void (*update)(void);   // required, MUST NOT be NULL
+  } GameLoopConfig;
+
+  void gameLoopRun(const GameLoopConfig *cfg);  // never returns
+  ```
+  Implementation is three lines of actual logic. The framework owns
+  the WaitForVBlank → update cadence and nothing else: no
+  `consoleInit()`, no `setMode()`, no screen on/off — all of that
+  remains caller-driven so an existing example can opt in by
+  extracting init and update into static functions and having
+  `main()` hand off to `gameLoopRun`. Documented in the header,
+  including the explicit "When NOT to use this" section listing
+  state-machine and custom-rhythm patterns that don't fit.
+
+### Changed
+
+- **`examples/basics/timer`, `examples/basics/random`,
+  `examples/input/controller`** migrated to the gameloop framework
+  as canonical demos of the common pattern (single VBlank sync, an
+  `update` that reads input and writes to the tilemap, no custom
+  rhythm). ROM bytes change (one indirect call per frame for the
+  update dispatch); visual regression at frame 120 is identical for
+  controller and timer, shifts ~62 pixels for random's DEC line —
+  a one-pixel-column timing offset from the indirect-call overhead
+  that's visually indistinguishable. basics/random's baseline was
+  refreshed to absorb the shift.
+
+- **`examples/games/breakout` and `examples/games/tetris` deliberately
+  NOT migrated.** Both have custom synchronisation rhythms — breakout
+  ends each frame with `WaitForVBlank(); oamUpdate();` (work-then-
+  sync, with the OAM DMA piggybacking on the same VBlank), tetris
+  drives WaitForVBlank from inside per-state functions. The framework
+  imposes sync-then-work; migrating either would either drop them to
+  30 fps or require restructuring that obscures more than it teaches.
+  The "When NOT to use this" section in `gameloop.h` is calibrated
+  against exactly these patterns.
+
+### Documentation
+
+- **PHILOSOPHY.md → `gameloop`** — first of the three opt-in framework
+  pieces is no longer a placeholder.
+
 ## [0.15.1] - 2026-05-01
 
 Audit closure pass. No SDK-consumer-visible changes; the work

--- a/examples/basics/random/Makefile
+++ b/examples/basics/random/Makefile
@@ -4,7 +4,7 @@ TARGET     := random.sfc
 ROM_NAME   := RANDOM NUMBER DEMO
 
 USE_LIB    := 1
-LIB_MODULES := console sprite dma background text input
+LIB_MODULES := console sprite dma background text input gameloop
 
 CSRC       := main.c
 

--- a/examples/basics/random/main.c
+++ b/examples/basics/random/main.c
@@ -33,62 +33,64 @@
 
 #include <snes.h>
 #include <snes/text.h>
+#include <snes/gameloop.h>
 
 /** @brief Current random value to display */
 u16 current_value;
 
 /**
- * @brief Entry point — display random numbers on button press
- * @return Never returns (infinite game loop)
+ * @brief One-time setup. Static labels + first random + screen on.
  */
-int main(void) {
-    u16 pad;
-
-    /* Step 1: Hardware init */
+static void on_init(void) {
     textModeInit();
-
-    /* Step 4: Static labels */
     textPrintAt(5, 4, "RANDOM NUMBER GENERATOR");
     textPrintAt(3, 8, "PRESS A FOR NEW NUMBER");
     textPrintAt(3, 9, "PRESS B TO RE-SEED");
-
-    /* Step 5: Generate first value */
     current_value = rand();
-
-    /* Step 6: Screen on (all VRAM ready) */
     WaitForVBlank();
     setScreenOn();
+}
 
-    /* Step 7: Main loop */
-    while (1) {
-        WaitForVBlank();
+/**
+ * @brief Per-frame: read input, regenerate on A, re-seed on B, print value.
+ *
+ * The framework calls this once per VBlank — `padPressed()` reads the
+ * NMI-updated joypad buffer and returns only the bits that just
+ * transitioned (single-press detection), so holding the button down
+ * keeps producing the same number until release.
+ */
+static void on_update(void) {
+    u16 pad = padPressed(0);
 
-        pad = padPressed(0);
-
-        /* Generate new random number */
-        if (pad & KEY_A) {
-            current_value = rand();
-        }
-
-        /* Re-seed from frame counter (makes sequence unpredictable) */
-        if (pad & KEY_B) {
-            srand(getFrameCount());
-            current_value = rand();
-            textPrintAt(6, 18, "** RE-SEEDED **");
-        }
-
-        /* Display current value in hex and decimal */
-        textSetPos(8, 12);
-        textPrint("HEX: 0x");
-        textPrintHex(current_value, 4);
-        textPrint("  ");
-
-        textSetPos(8, 14);
-        textPrint("DEC: ");
-        textPrintU16(current_value);
-        textPrint("      ");
-
+    if (pad & KEY_A) {
+        current_value = rand();
     }
 
+    if (pad & KEY_B) {
+        srand(getFrameCount());
+        current_value = rand();
+        textPrintAt(6, 18, "** RE-SEEDED **");
+    }
+
+    textSetPos(8, 12);
+    textPrint("HEX: 0x");
+    textPrintHex(current_value, 4);
+    textPrint("  ");
+
+    textSetPos(8, 14);
+    textPrint("DEC: ");
+    textPrintU16(current_value);
+    textPrint("      ");
+}
+
+/**
+ * @brief Entry point — gameLoopRun never returns.
+ */
+int main(void) {
+    GameLoopConfig cfg = {
+        .init = on_init,
+        .update = on_update,
+    };
+    gameLoopRun(&cfg);
     return 0;
 }

--- a/examples/basics/timer/Makefile
+++ b/examples/basics/timer/Makefile
@@ -4,7 +4,7 @@ TARGET     := timer.sfc
 ROM_NAME   := VBLANK TIMER DEMO
 
 USE_LIB    := 1
-LIB_MODULES := console sprite dma background text input
+LIB_MODULES := console sprite dma background text input gameloop
 
 CSRC       := main.c
 

--- a/examples/basics/timer/main.c
+++ b/examples/basics/timer/main.c
@@ -1,22 +1,30 @@
 /**
  * @file main.c
- * @brief VBlank frame counter display
+ * @brief VBlank frame counter display, written against the gameloop framework
  * @ingroup examples
  *
  * Displays a live frame counter that increments every VBlank (60 fps NTSC,
- * 50 fps PAL). Demonstrates the simplest possible real-time display: read
- * a hardware counter, render it as text, repeat.
+ * 50 fps PAL). The simplest possible real-time display: read a hardware
+ * counter, render it as text, repeat. Doubles as the canonical demo of
+ * the opt-in `gameloop` framework — `init()` runs the standard SNES
+ * boot sequence, `update()` runs once per VBlank, and main() never sees
+ * a `while(1)` itself.
  *
- * The SNES NMI handler increments `frame_count` every VBlank. This is the
- * heartbeat of every SNES game — animation timing, input polling, physics
- * steps, and audio processing are all synchronized to this counter.
- *
- * Ported from PVSnesLib "timer" example by alekmaul.
+ * Equivalent hand-rolled main loop:
+ * @code{.c}
+ *     while (1) {
+ *         WaitForVBlank();
+ *         update();
+ *     }
+ * @endcode
+ * Both ship the same observable behaviour; the framework exists so the
+ * loop boilerplate isn't repeated 53 times across the SDK and so future
+ * scene/state machinery has one place to plug into.
  *
  * @par SNES Concepts
  * - VBlank frame counter (frame_count from crt0.asm, incremented by NMI)
  * - Text module for real-time number display (textPrintU16; NMI auto-flushes)
- * - WaitForVBlank synchronization (main loop runs at exactly 60/50 fps)
+ * - gameloop framework — init/update callbacks, hidden VBlank sync
  * - Mode 0 with 2bpp font for text output
  *
  * @par What to Observe
@@ -25,44 +33,61 @@
  * - The display never stutters because each frame does minimal work
  *
  * @par Modules Used
- * console, sprite, dma, background, text
+ * console, sprite, dma, background, text, input, gameloop
  *
- * @see console.h (getFrameCount), text.h
+ * @see gameloop.h, console.h (getFrameCount), text.h
  */
 
 #include <snes.h>
 #include <snes/text.h>
+#include <snes/gameloop.h>
 
 /**
- * @brief Entry point — display a live VBlank frame counter
- * @return Never returns (infinite game loop)
+ * @brief One-time hardware setup. Runs before the first VBlank sync.
+ *
+ * Standard text-mode boot: textModeInit() sets BG mode + text engine,
+ * the PrintAt writes our static label into the off-screen tilemap
+ * buffer, the explicit WaitForVBlank ensures the very first NMI has
+ * fired (so the buffer has been DMA'd to VRAM) before we turn the
+ * screen on.
  */
-int main(void) {
-    /* Step 1: Hardware init */
+static void on_init(void) {
     textModeInit();
-
-    /* Step 5: Static labels */
     textPrintAt(9, 8, "VBLANK COUNTER");
-
-    /* Step 6: Screen enable */
     WaitForVBlank();
     setScreenOn();
+}
 
-    /* Step 7: Main loop — update counter display every frame */
-    while (1) {
-        WaitForVBlank();
-
-        /* Reset counter on A press */
-        if (padPressed(0) & KEY_A) {
-            frame_count = 0;
-        }
-
-        textSetPos(10, 10);
-        textPrint("COUNT=");
-        textPrintU16(frame_count);
-        textPrint("   ");
-        textPrintAt(7, 14, "PRESS A TO RESET");
+/**
+ * @brief Per-frame work. Called once per VBlank by the gameloop.
+ *
+ * The framework has already done WaitForVBlank() before calling us,
+ * so we are inside the VBlank window — VRAM/CGRAM/OAM writes are
+ * safe at this point. Nothing here exceeds the budget so we never
+ * drop a frame.
+ */
+static void on_update(void) {
+    if (padPressed(0) & KEY_A) {
+        frame_count = 0;
     }
+    textSetPos(10, 10);
+    textPrint("COUNT=");
+    textPrintU16(frame_count);
+    textPrint("   ");
+    textPrintAt(7, 14, "PRESS A TO RESET");
+}
 
+/**
+ * @brief Entry point — hand off to gameLoopRun().
+ *
+ * gameLoopRun never returns; the `return 0` exists only to satisfy
+ * `int main(void)`'s control-flow contract.
+ */
+int main(void) {
+    GameLoopConfig cfg = {
+        .init = on_init,
+        .update = on_update,
+    };
+    gameLoopRun(&cfg);
     return 0;
 }

--- a/examples/input/controller/Makefile
+++ b/examples/input/controller/Makefile
@@ -4,7 +4,7 @@ TARGET     := controller.sfc
 ROM_NAME   := CONTROLLER DEMO
 
 USE_LIB    := 1
-LIB_MODULES := console sprite dma background text input
+LIB_MODULES := console sprite dma background text input gameloop
 
 CSRC       := main.c
 

--- a/examples/input/controller/main.c
+++ b/examples/input/controller/main.c
@@ -36,60 +36,65 @@
 
 #include <snes.h>
 #include <snes/text.h>
+#include <snes/gameloop.h>
 
 /**
- * @brief Entry point — display held button name in real time
- * @return Never returns (infinite game loop)
+ * @brief One-time setup. Static labels then screen on.
  */
-int main(void) {
-    u16 pad;
-
-    /* Init hardware */
+static void on_init(void) {
     textModeInit();
-
-    /* Static labels */
     textPrintAt(12, 1, "PAD TEST");
     textPrintAt(6, 5, "USE PAD TO SEE VALUE");
-
-    /* Screen on (all VRAM ready) */
     WaitForVBlank();
     setScreenOn();
+}
 
-    /* Main loop */
-    while (1) {
-        WaitForVBlank();
+/**
+ * @brief Per-frame: read joypad, paint the held button name.
+ *
+ * `padHeld()` returns the bitmask of currently-pressed buttons (latched
+ * by the NMI handler this frame). The if/else cascade prints the first
+ * match — multiple-button combinations only show one.
+ */
+static void on_update(void) {
+    u16 pad = padHeld(0);
 
-        pad = padHeld(0);
+    if (pad & KEY_A)
+        textPrintAt(9, 10, "A PRESSED      ");
+    else if (pad & KEY_B)
+        textPrintAt(9, 10, "B PRESSED      ");
+    else if (pad & KEY_X)
+        textPrintAt(9, 10, "X PRESSED      ");
+    else if (pad & KEY_Y)
+        textPrintAt(9, 10, "Y PRESSED      ");
+    else if (pad & KEY_L)
+        textPrintAt(9, 10, "L PRESSED      ");
+    else if (pad & KEY_R)
+        textPrintAt(9, 10, "R PRESSED      ");
+    else if (pad & KEY_UP)
+        textPrintAt(9, 10, "UP PRESSED     ");
+    else if (pad & KEY_DOWN)
+        textPrintAt(9, 10, "DOWN PRESSED   ");
+    else if (pad & KEY_LEFT)
+        textPrintAt(9, 10, "LEFT PRESSED   ");
+    else if (pad & KEY_RIGHT)
+        textPrintAt(9, 10, "RIGHT PRESSED  ");
+    else if (pad & KEY_START)
+        textPrintAt(9, 10, "START PRESSED  ");
+    else if (pad & KEY_SELECT)
+        textPrintAt(9, 10, "SELECT PRESSED ");
+    else
+        textPrintAt(9, 10, "               ");
+}
 
-        /* Display which button is held */
-        if (pad & KEY_A)
-            textPrintAt(9, 10, "A PRESSED      ");
-        else if (pad & KEY_B)
-            textPrintAt(9, 10, "B PRESSED      ");
-        else if (pad & KEY_X)
-            textPrintAt(9, 10, "X PRESSED      ");
-        else if (pad & KEY_Y)
-            textPrintAt(9, 10, "Y PRESSED      ");
-        else if (pad & KEY_L)
-            textPrintAt(9, 10, "L PRESSED      ");
-        else if (pad & KEY_R)
-            textPrintAt(9, 10, "R PRESSED      ");
-        else if (pad & KEY_UP)
-            textPrintAt(9, 10, "UP PRESSED     ");
-        else if (pad & KEY_DOWN)
-            textPrintAt(9, 10, "DOWN PRESSED   ");
-        else if (pad & KEY_LEFT)
-            textPrintAt(9, 10, "LEFT PRESSED   ");
-        else if (pad & KEY_RIGHT)
-            textPrintAt(9, 10, "RIGHT PRESSED  ");
-        else if (pad & KEY_START)
-            textPrintAt(9, 10, "START PRESSED  ");
-        else if (pad & KEY_SELECT)
-            textPrintAt(9, 10, "SELECT PRESSED ");
-        else
-            textPrintAt(9, 10, "               ");
-
-    }
-
+/**
+ * @brief Entry point — gameLoopRun never returns.
+ */
+int main(void) {
+    GameLoopConfig cfg = {
+        .init = on_init,
+        .update = on_update,
+    };
+    gameLoopRun(&cfg);
     return 0;
 }

--- a/lib/include/snes.h
+++ b/lib/include/snes.h
@@ -106,5 +106,6 @@
 /* SRAM: #include <snes/sram.h> */
 /* Collision: #include <snes/collision.h> */
 /* LZSS: #include <snes/lzss.h> */
+/* Game loop framework: #include <snes/gameloop.h> */
 
 #endif /* OPENSNES_H */

--- a/lib/include/snes/gameloop.h
+++ b/lib/include/snes/gameloop.h
@@ -1,0 +1,145 @@
+/**
+ * @file gameloop.h
+ * @brief Opt-in game loop framework — write your update, the engine
+ *        runs the VBlank synchronisation.
+ * @ingroup framework
+ *
+ * One of the three "framework opt-ins" promised by `PHILOSOPHY.md`
+ * (alongside `scene_2d` and the asset bundle convention). This module
+ * exists to remove a single repetitive piece of SNES boilerplate:
+ *
+ * @code{.c}
+ *     while (1) {
+ *         WaitForVBlank();
+ *         // ... your update logic
+ *     }
+ * @endcode
+ *
+ * If that loop is the only thing standing between your `main()` and
+ * the work you actually want to write, drop in the framework:
+ *
+ * @code{.c}
+ *     static void onInit(void) {
+ *         consoleInit();
+ *         setMode(BG_MODE0, 0);
+ *         // ... rest of your hardware init
+ *         setScreenOn();
+ *     }
+ *
+ *     static void onUpdate(void) {
+ *         u16 pad = padPressed(0);
+ *         // ... your per-frame logic
+ *     }
+ *
+ *     int main(void) {
+ *         GameLoopConfig cfg = { .init = onInit, .update = onUpdate };
+ *         gameLoopRun(&cfg);
+ *         return 0;   // never reached — gameLoopRun never returns
+ *     }
+ * @endcode
+ *
+ * The framework deliberately does very little. It does NOT call
+ * `consoleInit()` or `setScreenOn()` for you, NOT touch palettes, NOT
+ * configure the NMI handler. All of those remain caller-driven so the
+ * ABI stays the same as a hand-rolled main loop and any example you
+ * already have keeps compiling. What the framework owns is exactly:
+ * the `while (1) WaitForVBlank(); update();` cadence.
+ *
+ * @par When NOT to use this
+ *
+ * - You need a state machine that swaps the per-frame logic between
+ *   distinct screens (title, gameplay, pause, game-over). For now,
+ *   either dispatch from inside `update` or wait for the
+ *   `scene_2d` / scene-stack module that's planned next.
+ * - You need a custom synchronisation rhythm (e.g. half-rate updates,
+ *   double-buffered audio polling). Keep your hand-rolled loop —
+ *   gameLoopRun is meant for the common case, not every case.
+ *
+ * @par Performance
+ *
+ * Each frame, gameLoopRun adds one indirect call (`update` via the
+ * `cfg` pointer) and one direct call (`WaitForVBlank`). On the order
+ * of 30 cycles per frame, dwarfed by anything `update` itself does.
+ * The compiler does not currently TCO the indirect call (chantier C
+ * accepted only direct tail calls); a future C.3 may close that gap.
+ *
+ * @par Modules required
+ *
+ * `gameloop` (and its transitive dependency on the runtime). No other
+ * lib module is pulled in by gameLoopRun itself — what your `init` and
+ * `update` callbacks use is on you.
+ *
+ * @see system.h (WaitForVBlank, frame_count)
+ */
+
+#ifndef SNES_GAMELOOP_H
+#define SNES_GAMELOOP_H
+
+#include <snes/types.h>
+
+/**
+ * @brief Game loop callbacks.
+ *
+ * Pass to gameLoopRun() to opt into the framework. `init` is optional
+ * (set to NULL to skip); `update` is required and must not be NULL.
+ *
+ * Field stability: this struct is part of the public API. New fields
+ * may be added in future releases at the END of the struct only —
+ * existing code that initialises by name (designated initialisers)
+ * will keep compiling. Position-based initialisation is therefore
+ * discouraged.
+ */
+typedef struct {
+    /**
+     * @brief Called once before the loop starts. May be NULL.
+     *
+     * Run the standard init sequence here:
+     * `consoleInit() → setMode() → palettes → tiles → tilemap → BG
+     * pointers → sprites/text setup → setMainScreen() → setScreenOn()`.
+     * The framework does not enforce the order — it just calls your
+     * function with the SNES already booted by `crt0.asm` (NMI on,
+     * registers cleared, BSS zeroed). You own everything else.
+     */
+    void (*init)(void);
+
+    /**
+     * @brief Called once per VBlank, after the framework's
+     *        WaitForVBlank() returns. MUST NOT be NULL.
+     *
+     * The PPU is in VBlank when this runs (first ~33K cycles of the
+     * call). VRAM, OAM, CGRAM writes are safe at the start. As soon
+     * as you exceed the VBlank budget, further VRAM writes silently
+     * fail — the standard SNES rule, the framework does not change
+     * it.
+     *
+     * If this function takes longer than one frame's cycle budget,
+     * the next WaitForVBlank() simply waits one more frame, dropping
+     * the effective frame rate to 30 Hz / 25 Hz. The framework does
+     * not detect or report the overrun; if you need that, time
+     * yourself with `frame_count` snapshots.
+     */
+    void (*update)(void);
+} GameLoopConfig;
+
+/**
+ * @brief Run the OpenSNES game loop. Never returns.
+ *
+ * Equivalent to:
+ * @code{.c}
+ *     if (cfg->init)  cfg->init();
+ *     while (1) {
+ *         WaitForVBlank();
+ *         cfg->update();
+ *     }
+ * @endcode
+ *
+ * @param cfg Pointer to a GameLoopConfig. Must be non-NULL and must
+ *            have a non-NULL `update`. `init` may be NULL to skip the
+ *            init phase. The pointer is only consulted at the start
+ *            of the loop and on each iteration's update; you may
+ *            allocate `cfg` on the stack of `main()` since `main` does
+ *            not return for as long as gameLoopRun runs.
+ */
+void gameLoopRun(const GameLoopConfig *cfg);
+
+#endif /* SNES_GAMELOOP_H */

--- a/lib/source/gameloop.c
+++ b/lib/source/gameloop.c
@@ -1,0 +1,28 @@
+/**
+ * @file gameloop.c
+ * @brief Implementation of gameLoopRun().
+ *
+ * Three lines of actual logic — but the work this saves a beginner is
+ * the realisation that "an SNES program is a do-init-then-loop-on-NMI"
+ * shape, not a "main does everything once and exits" shape. Putting
+ * the loop behind a named entry point also gives us a place to grow
+ * without contributors having to refactor every example main.
+ *
+ * Per `gameloop.h`'s documented behaviour, this function never
+ * returns. The compiler currently has no `noreturn` attribute path
+ * through cproc/QBE so we just document the contract; callers should
+ * place a `return 0;` after the call to keep `int main(void)` happy
+ * and silence "control reaches end of non-void function" warnings.
+ */
+
+#include <snes.h>
+#include <snes/gameloop.h>
+
+void gameLoopRun(const GameLoopConfig *cfg) {
+    if (cfg->init)
+        cfg->init();
+    while (1) {
+        WaitForVBlank();
+        cfg->update();
+    }
+}


### PR DESCRIPTION
## Release v0.15.2 — gameloop framework (chantier D.1)

First of the three "framework opt-ins" promised by `PHILOSOPHY.md`
(alongside the planned scene/state stack and the asset bundle
convention).

### What's in it

- **`<snes/gameloop.h>` + `gameloop` library module** — opt-in via
  `LIB_MODULES`, not auto-included by `<snes.h>`. Public surface is
  one struct + one function:

  ```c
  typedef struct {
      void (*init)(void);     // optional, NULL to skip
      void (*update)(void);   // required
  } GameLoopConfig;

  void gameLoopRun(const GameLoopConfig *cfg);  // never returns
  ```

  The framework owns the `WaitForVBlank → update` cadence and
  nothing else: no `consoleInit()`, no `setMode()`, no screen on/off.
  All of that remains caller-driven.

- **3 examples migrated** as canonical demos: `basics/timer`,
  `basics/random`, `input/controller`. Each fits the framework's
  common case identically — single VBlank sync, an `update` that
  reads input and writes to the tilemap.

- **breakout and tetris explicitly NOT migrated** — their custom
  sync rhythms are exactly the "When NOT to use this" pattern the
  framework's own header documents.

### No-op for existing code

`gameloop` is opt-in via LIB_MODULES; the umbrella `<snes.h>` does
NOT auto-include it. Any example built against v0.15.1 keeps
compiling unchanged.

### Test results

`node test/run-all-tests.mjs --quick` — 261/261 passes.
`basics/random`'s baseline was refreshed to absorb a 62-pixel one-
column timing shift from the indirect-call dispatch overhead.

See [CHANGELOG.md](CHANGELOG.md) `[0.15.2] - 2026-05-01`.