### PR TITLE
fix: engine review follow-ups (P0-1, P1-1, P1-3, B1 milestone)

### DIFF
--- a/.claude/STRUCTURAL_DEFECTS.md
+++ b/.claude/STRUCTURAL_DEFECTS.md
@@ -1223,6 +1223,61 @@ free**: `likemario`, `mapandobjects`, `tetris`, `continuous_scroll`,
   bank `$00`) remains the real win for user-facing ROMs; the above only
   buys SDK-example headroom and metric clarity.
 
+**Increment 1 — 2026-06-20 (`wip/b1-bank0-pointers`):**
+
+Audited the map path end-to-end (the worst bank-`$00` offender: BG1 maps
+are 18-25 KB and several examples pinned them to bank `$00`). Findings:
+
+- Post-A6/A7 the pointer ABI is **already 4-byte / bank-carrying**, and
+  `mapLoad`'s *load-time* path is already bank-aware (it reads the bank
+  byte of `layer1map`/`layertiles`/`tilesprop` and DMAs `layertiles` +
+  `tilesprop` into `$7E` WRAM from any bank).
+- **The one remaining lib offender**: the *runtime* scroll/query readers
+  (`_mapDAS1`, `_phb1`, `_pvb1`, `mapGetMetaTile`, `mapGetMetaTilesProp`
+  in `lib/source/map.asm`) hardcoded `lda #$00 / pha / plb` to force
+  DB=`$00` before `lda 0,x` — so the layer-1 map *had* to live in bank
+  `$00` even though its bank byte was already stored in `maptile_L1b`.
+  **Fixed**: all 5 sites now `lda maptile_L1b` (honour the stored bank).
+  Backward-compatible — an example whose map stays in bank `$00` has
+  `maptile_L1b=$00`, identical behaviour. Whole suite 293/293 unchanged.
+- **Proven end-to-end** on `maps/mapscroll`: pinned its 25 KB map +
+  tileset data to bank `2` (`data.asm` `.section ".rodata2" semifree
+  bank 2`). Bank `$00` free went **12 → 17093 bytes**; visual regression
+  (incl. the Mesen2 phase + scrolling) stayed pixel-identical.
+
+**Remaining for B1 (not yet done):**
+1. The same per-example data relocation for the other `mapLoad` users.
+   **Done**: `maps/mapscroll` (25 KB → bank 2) and `maps/tiled` (13 KB →
+   bank 2). **Remaining**: `mapandobjects`, `slopemario` also read the map
+   via **C pointers** (see #2), so they can't move until that's resolved.
+2. **C-level pointer-deref of ROM** (`games/likemario` does
+   `map_data = (u16*)mapmario; … map_data[i]`). **Resolved 2026-06-20 —
+   it's a compiler-codegen wall, split into its own sub-chantier.**
+   Disassembled `map_get_tile_prop` in `likemario`'s `main.c.asm`:
+   - Reading a *fixed-address* global pointer array IS bank-aware —
+     `map_row_ptrs[ty]` builds a 24-bit pointer (`#:map_row_ptrs` for the
+     bank) and uses `lda [tcc__r9]`.
+   - But dereferencing a *runtime* pointer value is **hardcoded to bank
+     `$00`**: `… tax / lda.l $0000,x` for both `map_row_ptrs[ty][tx]` and
+     `tile_props[…]`. Only the low 16 bits of the (4-byte, post-A6)
+     pointer are used; the bank byte is discarded at the load.
+   So `*ptr` / `ptr[i]` on ROM data always reads bank `$00`, regardless of
+   the pointer's stored bank. This is the same root behaviour as the
+   documented "`sta.l $0000,x` always reads bank `$00`" constraint (see
+   B2) applied to *reads through a runtime pointer*. Consequence:
+   `likemario`, `mapandobjects`, `slopemario` (which read the map via C
+   pointers, not `mapLoad`'s runtime) **cannot** move their map out of
+   bank `$00` until cc65816/QBE emits a bank-aware load for runtime
+   pointer derefs (use the pointer's bank byte → `lda [dp],y` long
+   indirect). That is a **compiler** change, not a lib or data-section
+   one — track it as a Category-A/B-adjacent codegen sub-chantier, shared
+   root with B2.
+3. A non-fragile bank-assignment policy (hand-picking `bank N` per example
+   collides as ROMs grow — the multi-bank-fallback problem from the parent
+   entry). Until then, per-example pins are acceptable for SDK examples.
+4. Re-tune `BANK0_FAIL_THRESHOLD` / `--warn-threshold` once the tight
+   examples have real headroom, and fix the symmap metric (sub-task a).
+
 ---
 
 #### B2. C RAM forced below `$2000` 🔴

--- a/.claude/STRUCTURAL_DEFECTS.md
+++ b/.claude/STRUCTURAL_DEFECTS.md
@@ -1168,11 +1168,60 @@ mechanical (each is ≤ 30 LOC of C + ASM helper); the audit + migration
   applicable.
 
 **References**:
-- `compiler/ABI.md:303-314` (pointer is 2 bytes).
+- `compiler/ABI.md` "Type sizes" table (pointer is 4 bytes post-A6/A7; the
+  16-bit *short* pointer this entry is about is the pre-A6 model — see the
+  investigation log re: which helpers still assume bank `$00`).
 - `lib/include/snes/dma.h` (existing `*Bank` variants).
 - `KNOWN_LIMITATIONS.md` "Bank `$00` ROM overflow".
 - `.claude/rules/bank0_budget.md` (the ratchet policy).
 - 2026-05-07 audit § 8 / § 15-#3 / § 11 (the bank-`$00`-tightness map).
+
+**Investigation log — 2026-06-20 (P1-2 from the engine review):**
+
+Measured the 11 currently-tight examples (all report **exactly 12 bytes
+free**: `likemario`, `mapandobjects`, `tetris`, `continuous_scroll`,
+`mode5`, `mode7`, `mode7_perspective`, `window`, `mapscroll`, `slopemario`,
+`tiled`). Two findings refine — but do **not** invalidate — this entry:
+
+1. **The uniform "12 bytes" is partly a measurement artifact.** In every
+   tight example the *highest* bank-`$00` symbol is a `__opensnes_force_emit_*`
+   anchor sitting at `$FFF0` (or `$FFE0`). These are inert `const` function
+   pointers (4 bytes, nothing reads them at runtime); WLA's SUPERFREE
+   allocator tucks them into the **unused gaps of the interrupt-vector
+   table** ($FFE0-$FFE3, $FFF0-$FFF3). `symmap.py`
+   (`check_bank0_rom_overflow`, line ~347) then computes
+   `free = 0x10000 - (highest + size) = 0x10000 - 0xFFF4 = 12`, i.e. it
+   measures to the **top of the bank**, ignoring the 64-byte header/vector
+   reservation ($FFC0-$FFFF) and getting anchored to a vector-gap symbol.
+   So "12" is really "the leftover of the vector-table region," not a
+   general-allocation headroom figure.
+
+2. **But bank `$00` is genuinely near-full anyway.** Excluding the anchors,
+   the highest *real* code/data symbol is already at ~`$FFB6`-`$FFB8` (just
+   below the `$FFC0` header), and the linker has spilled other force-emit
+   anchors (`getFrameCount`, `scopeCalibrate`, …) all the way to **bank
+   `$02`** — proof that no 4-byte gap remained in bank `$00` *or* `$01`. The
+   packing is real; the artifact only explains why the *number* is a
+   suspiciously-uniform 12.
+
+**Consequences for the fix:**
+- The silent-corruption risk is correctly gated by the *separate* spill
+  check (const data in bank `$01+`), which is unaffected by the artifact.
+  The "free < threshold" ratchet is a secondary proxy; its number is
+  cosmetically wrong but errs **safe** (alarms early).
+- Two cheap, independent sub-tasks worth splitting out of the 2-3 week B1:
+  (a) **symmap metric honesty** — measure free against the header start
+  ($FFC0) and/or exclude vector-region anchors from `highest`, so the
+  reported number reflects real allocatable headroom. Caution: this shifts
+  every example's reported "free" and may flip ratchet status — re-tune
+  `BANK0_FAIL_THRESHOLD`/`--warn-threshold` in the same change.
+  (b) **route force-emit anchors out of bank `$00`** — they're inert, so
+  unlike the abandoned all-`emitdat`-to-bank-1 attempt (2026-05-14) they
+  can move without touching real const data. Needs a way to bias *only*
+  the `__opensnes_force_emit_*` SUPERFREE sections to high banks.
+- The headline B1 fix (24-bit `*Bank` helper variants so user assets leave
+  bank `$00`) remains the real win for user-facing ROMs; the above only
+  buys SDK-example headroom and metric clarity.
 
 ---
 

--- a/.claude/notes/archive/shmup_1942_macro_hide_nonbug.md
+++ b/.claude/notes/archive/shmup_1942_macro_hide_nonbug.md
@@ -1,0 +1,77 @@
+---
+name: shmup_1942 "macro hide breaks bullet firing" — DEBUNKED (2026-06-20)
+description: A suspected cc65816 codegen footgun (commit 7113039) claiming that inlining enemy_hide/bullet_hide as preprocessor macros instead of static functions broke the bullet-firing path in examples/games/shmup_1942. Investigated with the regression_method.md bisection/repro workflow and proven NON-REPRODUCIBLE on the current toolchain. No code change needed; recorded so the open question from the 2026-06-20 engine review is closed and nobody re-chases it.
+type: project
+---
+
+## Verdict: not a bug. The macro form fires bullets correctly.
+
+Commit `7113039` ("fix(examples): shmup_1942 — restore bullet firing
+(revert inline-macro hides)") restored `enemy_hide`/`bullet_hide` from
+`#define` macros to `static` functions and stated, honestly, that it had
+**no root cause** — "functions work, macros break the bullet firing path",
+suspected as a cc65816 codegen quirk (bank placement / inlining /
+side-effect fence around `oamMemory[]`). The 2026-06-20 engine review
+flagged this as P1-1 (a revert-without-root-cause, violating
+`.claude/rules/regression_method.md`).
+
+## What the investigation found (three independent proofs)
+
+1. **Semantic equivalence.** `OAM_WRITE(_id, ...)` parenthesises `_id`
+   (`u16 _o = (u16)(_id) << 2;`), so `bullet_hide(i)` as a macro expands
+   to exactly what the function body does. No operator-precedence or
+   double-evaluation hazard (`i` and the OAM-base constants are
+   side-effect-free).
+
+2. **Byte-identical codegen on the firing path.** Built both variants
+   (`make clean && make`), captured `main.c.asm`, normalised QBE's local
+   label-number suffixes (`@name.NN` → `@name.N`, which shift only because
+   the absent `*_hide` functions move the global label counter), and
+   diffed `bullet_fire`: **182 lines, identical**. The macro/function
+   choice changes only where `*_hide` is emitted (inlined at call sites
+   vs one `.text.*_hide SUPERFREE` section), never `bullet_fire`.
+
+3. **Runtime confirmation (Mesen2).** Built the macro variant, loaded it,
+   held **A**, ran frames, read hardware OAM at the bullet slots
+   (`BULLET_OAM_BASE=9` → OAM byte 36, 8 slots):
+   - baseline: all 8 bullets hidden (`Y=0xEF=239`, i.e. `BULLET_HIDE_Y-1`)
+   - after firing: slot 0 `X=0x78 Y=0x77(119)`, then `Y=0x63(99)` while
+     slot 1 appears at `Y=0x83(131)` — bullets spawn and stream upward.
+   Firing works in the *allegedly broken* macro ROM.
+
+   Bank $00 also has **5138 bytes free** for this example, so the
+   "macros inline more code → bank $00 spill → garbage" theory is
+   impossible here (a handful of inlined `OAM_WRITE` sites are tens of
+   bytes, not 5 KB).
+
+## Most likely real story
+
+The "intermediate broken state" the commit describes (text module
+reverted, hides still macros) carried **another** difference that broke
+firing — an incomplete text-module revert and/or the separately-tracked
+bullet-despawn bug, which later commits fixed independently
+(`< -BULLET_SPRITE` → `< -12` → today's `< 0`). The macro→function swap
+rode along with the real fix and got the blame. Classic
+symptom-vs-cause misattribution — exactly what `regression_method.md`
+exists to prevent.
+
+## State left behind
+
+- No code change. `examples/games/shmup_1942/main.c` keeps the `static`
+  function form (committed state) — it is correct and idiomatic; this
+  note is *not* a call to switch back to macros, just a record that the
+  macro form is not dangerous.
+- The example README has **no** macro-vs-function footgun entry (the
+  commit message claimed it added one to "the README's existing footgun
+  list", but no such entry exists today — nothing to remove).
+- The cc65816 conditional-JSL note in this folder
+  (`cc65816_conditional_jsl_codegen_bug.md`) is a *different*, real (now
+  silently fixed) codegen issue — don't conflate the two.
+
+## If the symptom ever returns
+
+Re-run the same three-step proof: (1) check `OAM_WRITE` macro hygiene,
+(2) normalise-and-diff `bullet_fire` in `main.c.asm` between the two
+forms, (3) read OAM at byte 36 in Mesen2 after holding A. If (2) ever
+*differs*, that is a genuine codegen bug — bisect the compiler per
+`regression_method.md` and reopen.

--- a/.claude/notes/tech/enhancement_chips_research.md
+++ b/.claude/notes/tech/enhancement_chips_research.md
@@ -51,6 +51,41 @@ battle system.
 main 65816 and SA-1. Our compiler output would work on SA-1 unmodified
 (same ISA). Just need ROM header + memory map support.
 
+## SA-1 SIWP/CIWP polarity — DISPUTED, kept at $FF (2026-06-20)
+
+Investigated the P1-3 finding (crt0 writes `$FF` to SIWP `$2229` under the
+guess "*maybe bit=1 means WRITABLE*"). **Documentation and our emulators
+flatly disagree on the polarity — and the emulators win for now.**
+
+Documentation side (says `$FF` is wrong, `$00` writable):
+- [Super Famicom Dev Wiki — SA-1 registers](https://wiki.superfamicom.org/sa-1-registers):
+  "$2229 ... 0 = Disable protection, 1 = Enable protection"; full write
+  access = `$00`.
+- [PeterLemon/SNES SNES_SA-1.INC](https://github.com/PeterLemon/SNES/blob/master/LIB/SNES_SA-1.INC)
+  names it "SA-1 I-RAM Write Protection (S-CPU Controlled)".
+
+Emulator side (says `$FF` is correct), tested in Mesen2 (our accuracy
+reference) on `sa1_hello`:
+- `$FF` → crt0 I-RAM self-test passes, `sa1_status=$A5`, `$3000=$A5`.
+- `$00` → self-test **fails**, `sa1_status=$FF`, `$3000=$DB` (the SNES-CPU
+  write to I-RAM was blocked).
+- snes9x agrees with Mesen2 (the CI suite is green with `$FF`).
+
+### LESSON (the important part)
+
+I initially trusted the wiki, flipped crt0 to `$00`, and it **broke** SA-1
+in Mesen2. Reverted to `$FF`. *Empirical test before doc-driven "fix"* — the
+project's own rule (`debugging.md`: verify in Mesen2, never guess) would
+have caught this up front. Don't flip this again without a **real SA-1
+cartridge** test that proves the wiki polarity; the crt0 self-test
+(`_sa1_iram_fail` → `sa1_status=$FF`) is the runtime safety net either way.
+
+**State:** crt0 stays at `$FF` (both sites); `KNOWN_LIMITATIONS.md`,
+`docs/hardware/REGISTERS.md`, `docs/tutorials/sa1.md` rewritten to present
+the conflict honestly instead of asserting either polarity. **Open:**
+hardware verification; and the whose-writes detail (does SIWP gate S-CPU
+or SA-1 writes?) — unresolved by primary sources.
+
 ## Next Steps
 
 - [ ] Study SuperFX memory map and cartridge header format

--- a/.claude/rules/doc_consistency.md
+++ b/.claude/rules/doc_consistency.md
@@ -26,6 +26,16 @@ opt-in list.
    v0.16.0 shipped the new `scene_stack` example. `CHANGELOG.md` is
    exempt — historical entries freeze a past state on purpose.
 
+4. **ABI prototypes quoted in `compiler/ABI.md`** must match the canonical
+   declaration in `lib/include/snes/*.h`. `ABI.md` is the canonical ABI
+   reference; a stale prototype there silently invalidates its whole
+   stack-offset table. Caught historically as the `oamSet` worked example
+   pinning a 6-arg `(u8 id, u16 x, u16 y, u16 attr, u8 size, u16 tile)`
+   signature while the real API is 7-arg `(u16 id, u16 x, u16 y, u16 tile,
+   u16 palette, u16 priority, u16 flags)` — every offset in the table was
+   wrong. Only prototypes whose function name exists in a header are
+   checked; illustrative prototypes and code-block *calls* are ignored.
+
 ## Mandatory workflow
 
 Before committing any change that touches one of those classes:
@@ -47,6 +57,10 @@ It exits 0 on green, 1 on drift with an actionable message per finding.
   rules. The canonical pattern is "every example" / "the full suite" —
   see `testing.md:14` and `nmi_audit.md:57` for the form. Hard-coded
   numbers belong in changelog snapshots and release notes only.
+- **ABI prototypes in `compiler/ABI.md`**: whenever a public function's
+  signature changes in `lib/include/snes/*.h`, update the matching worked
+  example in `ABI.md` in the same commit — the signature line, the codegen
+  push list, and the stack-offset table all move together.
 
 ## Adding a new anchor
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,11 +79,13 @@ jobs:
       - name: Run check_doc_drift.py
         # Anchored claims that drift behind code: version macros in
         # lib/include/snes.h, ROADMAP "Current Status: post-vX.Y.Z" line,
-        # and "<N> examples" counts in active rule files. Caught
-        # historically as v0.1.0-dev macro stuck while the project shipped
-        # v0.16.0; "post-v0.13.0" ROADMAP three minors behind; and "53
-        # examples" sticking after v0.16.0 added the 54th. Fix policy lives
-        # in .claude/rules/doc_consistency.md.
+        # "<N> examples" counts in active rule files, and ABI prototypes in
+        # compiler/ABI.md vs lib/include/snes/*.h. Caught historically as
+        # v0.1.0-dev macro stuck while the project shipped v0.16.0;
+        # "post-v0.13.0" ROADMAP three minors behind; "53 examples" sticking
+        # after v0.16.0 added the 54th; and the oamSet worked example pinning
+        # a stale 6-arg signature. Fix policy lives in
+        # .claude/rules/doc_consistency.md.
         run: python3 devtools/check_doc_drift.py
 
   nmi-race-tests:

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -151,15 +151,31 @@ before committing.
 
 ## Toolchain & emulator coverage
 
-### 🟡 SA-1 SIWP register init is an unsourced assumption
-`templates/crt0.asm:557+` initialises the SA-1 by writing `$FF` to register
-`$002229` (SIWP) with the comment "*maybe bit=1 means WRITABLE*". This came
-from observation, not from a published spec. If a future SA-1 cartridge revision
-behaves differently, the init silently fails and the chip is half-configured.
+### 🟡 SA-1 SIWP/CIWP write-protection polarity is disputed
+`templates/crt0.asm` enables SA-1 I-RAM access by writing the SIWP register
+`$002229` (twice: early init ~`:519-526`, and the SA-1 boot block
+~`:636-642`), value `$FF`. **The polarity of this register is genuinely
+contested between documentation and emulators:**
 
-**Mitigation:** none currently. If your project depends on SA-1 in a serious
-way, exercise it on real hardware before shipping. We track this in
-`memory/enhancement_chips_research.md`.
+- The [Super Famicom Dev Wiki](https://wiki.superfamicom.org/sa-1-registers)
+  and fullsnes say each bit *enables* write-protection for one 256-byte
+  I-RAM page (bit=1 protects, bit=0 writable), i.e. `$00` = all writable.
+- **Mesen2** (this project's accuracy reference) and **snes9x** behave the
+  *opposite* way. Tested empirically (2026-06-20): with `$FF` the crt0
+  I-RAM self-test passes (`sa1_status=$A5`); with `$00` the SNES-CPU write
+  to I-RAM is blocked and the self-test fails (`sa1_status=$FF`).
+
+OpenSNES writes `$FF` because that is what works on the emulators we
+validate against. A `$00` "fix" (matching the wiki) **breaks** SA-1 in
+Mesen2/snes9x and was reverted — do not re-apply it without a real-hardware
+test that proves the wiki polarity.
+
+**Mitigation:** the crt0 self-test (`:639-647`: write `$42` to I-RAM, read
+back, fail to `sa1_status=$FF`) means a wrong choice is **detected** at
+runtime — `sa1IsReady()` returns false unless the SA-1 reaches `$A5`, so
+the failure is not silent. If your project depends on SA-1, verify on a
+real cartridge before shipping. Background + sources:
+`.claude/notes/tech/enhancement_chips_research.md`.
 
 ### 🟢 SuperFX: snes9x does not detect the GSU chip — Mesen2-headless covers it in CI
 The opensnes-emu CI test harness runs ROMs through snes9x's libretro core

--- a/compiler/ABI.md
+++ b/compiler/ABI.md
@@ -297,26 +297,28 @@ Constraints to respect:
 `lib/include/snes/sprite.h` declares:
 
 ```c
-void oamSet(u8 id, u16 x, u16 y, u16 attr, u8 size, u16 tile);
+void oamSet(u16 id, u16 x, u16 y, u16 tile, u16 palette, u16 priority, u16 flags);
 ```
 
 A C call:
 
 ```c
-oamSet(0, 100, 50, 0x30, 0, 0x100);
+oamSet(0, 100, 50, 0x100, 0, 3, 0x40);
 ```
 
 Generates:
 
 ```asm
-    pea.w 0          ; id (zero-extended u8)
+    pea.w 0          ; id
     pea.w 100        ; x
     pea.w 50         ; y
-    pea.w 48         ; attr (0x30)
-    pea.w 0          ; size (zero-extended u8)
-    pea.w 256        ; tile
+    pea.w 256        ; tile (0x100)
+    pea.w 0          ; palette
+    pea.w 3          ; priority
+    pea.w 64         ; flags (0x40)
     jsl oamSet
-    plx              ; pop 6 args (12 bytes total)
+    plx              ; pop 7 args (14 bytes total)
+    plx
     plx
     plx
     plx
@@ -328,14 +330,17 @@ Inside `oamSet`'s ASM (with framesize F):
 
 | Offset | Param |
 |--------|-------|
-| `F+4`  | tile (rightmost arg, low byte) |
-| `F+6`  | size (zero-extended u8 — only low byte meaningful) |
-| `F+8`  | attr |
-| `F+10` | y |
-| `F+12` | x |
-| `F+14` | id (zero-extended u8) |
+| `F+4`  | flags (rightmost arg, last pushed) |
+| `F+6`  | priority |
+| `F+8`  | palette |
+| `F+10` | tile |
+| `F+12` | y |
+| `F+14` | x |
+| `F+16` | id (leftmost arg, first pushed) |
 
-For the assembly source, see `lib/source/sprite_oamset.asm`.
+All seven parameters are `u16`, so each occupies a 2-byte stack slot.
+For the assembly source, see `lib/source/sprite_oamset.asm` (whose header
+comment lists the same `16,s … 4,s` offsets at framesize 0).
 
 ---
 

--- a/devtools/check_doc_drift.py
+++ b/devtools/check_doc_drift.py
@@ -19,6 +19,15 @@ Anchored claims currently watched:
      Historical entries in ``CHANGELOG.md`` are exempt — they freeze a
      past state.
 
+  4. Public C function prototypes quoted in ``compiler/ABI.md`` must match
+     the canonical declaration in ``lib/include/snes/*.h``. ABI.md is the
+     canonical ABI reference; a stale prototype there makes its whole
+     stack-offset table wrong. Caught historically as the ``oamSet`` worked
+     example pinning a 6-arg ``(u8 id, u16 x, u16 y, u16 attr, u8 size,
+     u16 tile)`` signature while the real API is the 7-arg ``(u16 id,
+     u16 x, u16 y, u16 tile, u16 palette, u16 priority, u16 flags)`` —
+     the entire offset table was off.
+
 Why this exists: the v0.1.0-dev macro stuck at v0.16.0, the post-v0.13.0
 ROADMAP stale by three minor versions, and the "53 examples" / "54 examples"
 count drift across rules — all of these were caught by a 1-day external
@@ -211,6 +220,160 @@ def check_examples_count(canonical: int) -> list[str]:
 
 
 # --------------------------------------------------------------------------
+# Check 4: ABI.md C prototypes vs canonical headers
+# --------------------------------------------------------------------------
+
+HEADER_DIR = "lib/include/snes"
+
+# A C function prototype: <return type> <name>(<params>);
+#
+# Deliberately strict to avoid matching prose with parentheses:
+#   * the return type and name sit on a single line (no newline in `ret`,
+#     none between `name` and `(`) — a real declaration never wraps there;
+#   * the parameter list admits only the characters of an actual param list
+#     (identifiers, whitespace, `*`, `,`, `[]`) — backticks, prose
+#     punctuation and nested `(` are excluded, so a sentence like
+#     ``handshakes (`vblank_flag`, ...)`` can never be mistaken for one.
+# Function-pointer params are not modelled (the SDK has none); such a
+# prototype simply won't match and is skipped rather than mis-parsed.
+_C_PROTO_RE = re.compile(
+    r"(?P<ret>[A-Za-z_][\w \t\*]*?)\b(?P<name>[A-Za-z_]\w*)[ \t]*"
+    r"\((?P<params>[\w\s\*,\[\]]*)\)[ \t]*;",
+)
+
+# C block/line comments stripped before prototype scanning.
+_C_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_C_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+
+
+def _strip_c_comments(text: str) -> str:
+    """Blank out C comments while preserving offsets and line numbering.
+
+    Each comment is replaced by spaces and its own newlines, so a match's
+    ``start()`` still maps to the right line in the original text.
+    """
+    def _blank(m: re.Match) -> str:
+        return "".join("\n" if ch == "\n" else " " for ch in m.group(0))
+
+    text = _C_BLOCK_COMMENT_RE.sub(_blank, text)
+    text = _C_LINE_COMMENT_RE.sub(_blank, text)
+    return text
+
+
+def _is_typed_param_list(params: str) -> bool:
+    """True if every parameter looks like a typed declaration (``type name``).
+
+    This is what separates a real prototype (``oamSet(u16 id, u16 x, ...)``)
+    from a *call* in a code block (``oamSet(0, 100, ...)``) or a fenced-code
+    language tag bleeding into the match. Function-call arguments are bare
+    literals / dotted expressions with no ``type name`` shape.
+    """
+    s = params.strip()
+    if s == "" or s == "void":
+        return True
+    for p in s.split(","):
+        toks = re.sub(r"\*", " * ", p).split()
+        idents = [t for t in toks if t != "*"]
+        # Need at least a type token and a name token, both plain C identifiers.
+        if len(idents) < 2:
+            return False
+        if not re.fullmatch(r"[A-Za-z_]\w*", idents[0]):
+            return False
+        if not re.fullmatch(r"[A-Za-z_]\w*", idents[-1]):
+            return False
+    return True
+
+
+def _normalize_param(decl: str) -> str:
+    """Normalize one parameter declaration to a canonical 'type name' string."""
+    decl = decl.strip()
+    if not decl or decl == "void":
+        return ""
+    # Trailing identifier is the parameter name; the rest is the type.
+    m = re.search(r"([A-Za-z_]\w*)\s*$", decl)
+    if not m:
+        return re.sub(r"\s+", " ", decl)
+    name = m.group(1)
+    typ = decl[: m.start()].strip()
+    typ = re.sub(r"\s*\*\s*", " *", typ)  # canonical pointer spacing
+    typ = re.sub(r"\s+", " ", typ).strip()
+    if not typ:  # bare type with no name (e.g. unnamed); keep as type only
+        return name
+    return f"{typ} {name}"
+
+
+def _normalize_signature(ret: str, name: str, params: str) -> str:
+    ret = re.sub(r"\s*\*\s*", " *", ret)
+    ret = re.sub(r"\s+", " ", ret).strip()
+    parts = [p for p in (_normalize_param(p) for p in params.split(",")) if p]
+    return f"{ret} {name}({', '.join(parts)})"
+
+
+def _header_signatures() -> dict[str, tuple[str, str]]:
+    """Map public function name -> (normalized signature, source 'file').
+
+    If a name is declared in more than one header, the first wins and the
+    duplicate is ignored (the ABI doc references a single canonical decl).
+    """
+    sigs: dict[str, tuple[str, str]] = {}
+    hdr_dir = repo_path(HEADER_DIR)
+    if not hdr_dir.is_dir():
+        return sigs
+    for hdr in sorted(hdr_dir.glob("*.h")):
+        text = _strip_c_comments(hdr.read_text(encoding="utf-8"))
+        for m in _C_PROTO_RE.finditer(text):
+            name = m.group("name")
+            ret = m.group("ret").strip()
+            params = m.group("params")
+            # Skip control-flow keywords masquerading as return types and
+            # anything that doesn't look like a declaration (e.g. 'if (...)').
+            if ret in ("", "return", "if", "while", "for", "switch", "sizeof"):
+                continue
+            if not _is_typed_param_list(params):
+                continue
+            norm = _normalize_signature(ret, name, params)
+            sigs.setdefault(name, (norm, hdr.name))
+    return sigs
+
+
+def check_abi_signatures() -> list[str]:
+    """ABI.md prototypes for public SDK functions must match the headers."""
+    abi = repo_path("compiler/ABI.md")
+    if not abi.is_file():
+        return []
+    headers = _header_signatures()
+    if not headers:
+        return []
+
+    drifts: list[str] = []
+    text = abi.read_text(encoding="utf-8")
+    for m in _C_PROTO_RE.finditer(_strip_c_comments(text)):
+        name = m.group("name")
+        if name not in headers:
+            continue  # illustrative prototype, not a real SDK function
+        ret = m.group("ret").strip()
+        if ret in ("return", "if", "while", "for", "switch", "sizeof"):
+            continue
+        params = m.group("params")
+        if not _is_typed_param_list(params):
+            continue  # a call or non-declaration, not a prototype
+        actual = _normalize_signature(ret, name, params)
+        expected, src = headers[name]
+        if actual != expected:
+            # Line number of the match start in the original text.
+            lineno = text.count("\n", 0, m.start()) + 1
+            drifts.append(
+                f"compiler/ABI.md:{lineno}: prototype for `{name}` is\n"
+                f"      {actual}\n"
+                f"    but {HEADER_DIR}/{src} declares\n"
+                f"      {expected}\n"
+                f"    — update the ABI.md worked example (signature, codegen "
+                f"push list, and the stack-offset table) to match the header"
+            )
+    return drifts
+
+
+# --------------------------------------------------------------------------
 # CLI
 # --------------------------------------------------------------------------
 
@@ -228,6 +391,7 @@ def run_checks(quiet: bool) -> int:
     all_drifts.extend(check_snes_h_version(canonical_ver))
     all_drifts.extend(check_roadmap_status(canonical_ver))
     all_drifts.extend(check_examples_count(canonical_n))
+    all_drifts.extend(check_abi_signatures())
 
     if all_drifts:
         print("DRIFT DETECTED:", file=sys.stderr)

--- a/docs/hardware/REGISTERS.md
+++ b/docs/hardware/REGISTERS.md
@@ -544,8 +544,17 @@ set and programming details, see `.claude/SA-1.md`.
 |----------|---------|-----|-------------|
 | CCNT | $2200 | W | SA-1 CPU control: reset, IRQ, NMI, 4-bit message to SA-1 |
 | CRV | $2203-$2204 | W | SA-1 Reset Vector (address SA-1 jumps to on release from reset) |
-| SIWP | $2229 | W | SNES I-RAM Write Protection (bit=1 means page is **writable**) |
-| CIWP | $222A | W | SA-1 I-RAM Write Protection (bit=1 means page is **writable**) |
+| SIWP | $2229 | W | SNES I-RAM Write Protection (**polarity disputed** — see note; OpenSNES writes `$FF`) |
+| CIWP | $222A | W | SA-1 I-RAM Write Protection (**polarity disputed** — see note; OpenSNES writes `$FF`) |
+
+> **SIWP/CIWP polarity is disputed.** The [Super Famicom Dev
+> Wiki](https://wiki.superfamicom.org/sa-1-registers) and fullsnes say each
+> bit *enables* protection for one 256-byte I-RAM page (so `$00` = all
+> writable, `$FF` = all protected). But **Mesen2** (our accuracy reference)
+> and **snes9x** behave the opposite way: with `$FF` the crt0 I-RAM
+> self-test passes (`sa1_status=$A5`), with `$00` it fails. OpenSNES writes
+> `$FF` because that is what works on the emulators we validate against. The
+> tie has not been broken on real SA-1 hardware. See `KNOWN_LIMITATIONS.md`.
 | SFR | $2300 | R | Status Flags: SA-1 IRQ/NMI pending, 4-bit message from SA-1 |
 
 **Typical boot sequence:**
@@ -557,10 +566,11 @@ sta.l $2203          ; CRV low
 lda.w #sa1_entry>>8
 sta.l $2204          ; CRV high (bank handled by mapping)
 
-; Enable I-RAM writes for both CPUs
+; Enable I-RAM writes for both CPUs ($FF = writable on Mesen2/snes9x;
+; polarity disputed vs the wiki — see the note above)
 lda #$FF
-sta.l $2229          ; SIWP — all pages writable by SNES
-sta.l $222A          ; CIWP — all pages writable by SA-1
+sta.l $2229          ; SIWP — I-RAM writable by SNES (per our emulators)
+sta.l $222A          ; CIWP — I-RAM writable by SA-1 (per our emulators)
 
 ; Release SA-1 from reset
 lda #$00

--- a/docs/tutorials/sa1.md
+++ b/docs/tutorials/sa1.md
@@ -52,10 +52,21 @@ The SA-1 also sees it at **$0000-$07FF** (its direct page region).
 This is how the two CPUs communicate: the main CPU writes data to I-RAM,
 the SA-1 reads it, computes results, writes them back, and signals "done."
 
-> **Write protection gotcha**: Both CPUs have independent write protection
-> registers (SIWP at $2229, CIWP at $222A). **Bit = 1 means WRITABLE**
-> (despite the register name). The default is $00 = all protected!
-> You must write $FF to enable writes.
+> **Write protection gotcha (disputed polarity)**: Both CPUs have
+> independent write-protection registers (SIWP at $2229, CIWP at $222A).
+> The polarity is genuinely contested:
+> - The [Super Famicom Dev Wiki](https://wiki.superfamicom.org/sa-1-registers)
+>   and fullsnes say **bit = 1 PROTECTS** a 256-byte page, so `$00` = all
+>   writable, `$FF` = all protected.
+> - **Mesen2** (our accuracy reference) and **snes9x** behave the *opposite*
+>   way: writing `$FF` leaves I-RAM writable (the crt0 self-test passes,
+>   `sa1_status=$A5`); writing `$00` blocks the writes and the self-test
+>   fails.
+>
+> OpenSNES writes **`$FF`** because that is what works on the emulators we
+> test against. If you target real hardware, verify this on a cartridge —
+> the tie is unbroken. The crt0 I-RAM self-test catches a wrong choice at
+> runtime (`sa1IsReady()` returns false).
 
 ## Getting Started
 
@@ -107,9 +118,10 @@ SA1Start:
     sep #$20
     .ACCU 8
 
-    ; Enable SA-1 I-RAM writes (CRITICAL!)
+    ; Enable SA-1 I-RAM writes (CRITICAL!). $FF = writable on Mesen2/snes9x;
+    ; polarity is disputed vs the wiki — see the gotcha box above.
     lda #$FF
-    sta.l $00222A           ; CIWP = $FF (bit=1 = WRITABLE)
+    sta.l $00222A           ; CIWP = $FF (writable per our emulators)
 
     ; Signal ready to main CPU
     lda #$A5
@@ -320,8 +332,13 @@ Mesen2 has a dedicated SA-1 debugger:
 4. **Watch $3000** — verify the $A5 magic byte appears after boot
 
 Common issues:
-- **SA-1 PC stuck at $0000**: CIWP not set — SA-1 can't write I-RAM
-- **I-RAM reads return $FF**: SIWP not set — main CPU can't read I-RAM
+- **SA-1 PC stuck at $0000**: reset vector ($2203/$2204) wrong, or I-RAM
+  write-protection (CIWP $222A) left in the protected state so the SA-1
+  can't write its handshake — set it the same way the crt0 does (`$FF` on
+  Mesen2/snes9x; see the polarity note above)
+- **I-RAM reads return $FF**: SIWP/CIWP only gate *writes*, never reads —
+  so this is not a protection problem; the SA-1 simply hasn't written
+  I-RAM yet (not released from reset, or wrong reset vector)
 - **Counter not incrementing**: Check that `$2200` was written correctly ($00 = release)
 
 ## Examples

--- a/examples/maps/mapscroll/data.asm
+++ b/examples/maps/mapscroll/data.asm
@@ -16,7 +16,10 @@ tilesetpal_end:
 .ends
 
 ;--- Map data (from tmx2snes) ---
-.section ".rodata2" superfree
+; B1 proof: pinned to bank 2 (out of bank $00). mapLoad + the scroll
+; runtime now honour the pointer's bank byte, so the 25 KB map no longer
+; has to sit in bank $00.
+.section ".rodata2" semifree bank 2
 
 mapdata:
 .incbin "res/BG1.m16"

--- a/examples/maps/tiled/data.asm
+++ b/examples/maps/tiled/data.asm
@@ -24,7 +24,9 @@ tilesetpal_end:
 ; maplevel01.t16: Metatile definitions (4 tiles per metatile)
 ; maplevel01.b16: Tile attributes (collision properties per metatile)
 ;------------------------------------------------------------------------------
-.section ".rodata2" superfree
+; B1: pinned out of bank $00 (bank 2). mapLoad + the scroll runtime honour
+; the pointer's bank byte, so the 13 KB map need not sit in bank $00.
+.section ".rodata2" semifree bank 2
 
 mapdata:
 .incbin "res/BG1.m16"

--- a/lib/source/map.asm
+++ b/lib/source/map.asm
@@ -502,10 +502,10 @@ _mapDAS1:
     phb
     sep #$20
     .ACCU 8
-    lda #$00
-    pha
-    plb
-    rep #$20
+    lda maptile_L1b                         ; DB = layer1map's bank (B1: was #$00,
+    pha                                     ; hardcoded bank $00; now honours the
+    plb                                     ; pointer's bank so the map can live
+    rep #$20                                ; outside bank $00)
     .ACCU 16
     lda 0,x
     plb
@@ -617,10 +617,10 @@ _phb1:
     phb
     sep #$20
     .ACCU 8
-    lda #$00
-    pha
-    plb
-    rep #$20
+    lda maptile_L1b                         ; DB = layer1map's bank (B1: was #$00,
+    pha                                     ; hardcoded bank $00; now honours the
+    plb                                     ; pointer's bank so the map can live
+    rep #$20                                ; outside bank $00)
     .ACCU 16
     lda 0,x
     plb
@@ -683,10 +683,10 @@ _pvb1:
     phb
     sep #$20
     .ACCU 8
-    lda #$00
-    pha
-    plb
-    rep #$20
+    lda maptile_L1b                         ; DB = layer1map's bank (B1: was #$00,
+    pha                                     ; hardcoded bank $00; now honours the
+    plb                                     ; pointer's bank so the map can live
+    rep #$20                                ; outside bank $00)
     .ACCU 16
     lda 0,x
     plb
@@ -1139,10 +1139,10 @@ mapGetMetaTile:
     phb
     sep #$20
     .ACCU 8
-    lda #$00
-    pha
-    plb
-    rep #$20
+    lda maptile_L1b                         ; DB = layer1map's bank (B1: was #$00,
+    pha                                     ; hardcoded bank $00; now honours the
+    plb                                     ; pointer's bank so the map can live
+    rep #$20                                ; outside bank $00)
     .ACCU 16
     lda 0,x
     plb
@@ -1200,10 +1200,10 @@ mapGetMetaTilesProp:
     phb
     sep #$20
     .ACCU 8
-    lda #$00
-    pha
-    plb
-    rep #$20
+    lda maptile_L1b                         ; DB = layer1map's bank (B1: was #$00,
+    pha                                     ; hardcoded bank $00; now honours the
+    plb                                     ; pointer's bank so the map can live
+    rep #$20                                ; outside bank $00)
     .ACCU 16
     lda 0,x
     plb

--- a/templates/crt0.asm
+++ b/templates/crt0.asm
@@ -514,10 +514,19 @@ FastStart:
     .ACCU 8
 
 .ifdef SA1
-    ; SA-1: Enable I-RAM writes for SNES CPU
-    ; Try $FF — maybe bit=1 means WRITABLE (not PROTECTED)
+    ; SA-1: Enable I-RAM writes for the SNES CPU via SIWP ($2229).
+    ; POLARITY IS DISPUTED — do not "fix" this to $00 without a hardware test:
+    ;   * Super Famicom Dev Wiki / fullsnes: bit=1 PROTECTS a 256-byte page,
+    ;     so $00 = all writable.
+    ;   * Mesen2 (our accuracy reference) and snes9x: $FF = writable, $00 =
+    ;     write-blocked. Empirically, $00 makes the crt0 I-RAM self-test
+    ;     below fail (sa1_status=$FF); $FF makes it pass (sa1_status=$A5).
+    ; We follow the emulators we actually test on (=$FF). The self-test is
+    ; the safety net if a future emulator/cartridge disagrees.
+    ; See KNOWN_LIMITATIONS.md "SA-1 SIWP/CIWP" and
+    ; .claude/notes/tech/enhancement_chips_research.md.
     lda #$FF
-    sta.l $002229           ; SIWP = $FF
+    sta.l $002229           ; SIWP = $FF (writable per Mesen2/snes9x)
 .endif
 
     ; Set up stack at $1FFF
@@ -629,8 +638,10 @@ FastStart:
     ; === SA-1 INIT ===
 
     ; 1. Disable I-RAM write protection (redundant with early init, but safe)
+    ;    $FF = writable per Mesen2/snes9x; polarity disputed vs the wiki —
+    ;    see the SIWP note at the early-init site above before changing.
     lda #$FF
-    sta.l $002229           ; SIWP: try $FF = all bits set = writable?
+    sta.l $002229           ; SIWP = $FF (writable per Mesen2/snes9x)
 
     ; 2. SELF-TEST: verify SNES CPU can write/read I-RAM
     ;    Use STA.L/LDA.L to force bank $00 (bypass DB)


### PR DESCRIPTION
Follow-ups from a full engine review (`/tmp/opensnes_review_2026-06-20.md`).
Five self-contained commits; every step validated with `make` + the quick
suite (293/293) and Mesen2 for the SA-1 work.

## Commits

**`45e537d` — P0-1: `oamSet` ABI doc drift + new sentinel guard**
`compiler/ABI.md` documented a stale 6-arg `oamSet` signature while the real
API is 7-arg (`sprite.h:352`), so its whole stack-offset table was wrong.
Fixed the signature, codegen push list, and offset table (matches
`sprite_oamset.asm`). Added `check_abi_signatures()` to
`devtools/check_doc_drift.py` so any future ABI.md/header prototype drift
fails `make lint-docs` and the CI `doc-drift` job.

**`fd53874` — P1-1: debunk shmup_1942 "macro hides break bullet firing"**
A prior commit reverted macros→functions "to restore firing" with no root
cause. Proven non-reproducible: `bullet_fire` codegen is byte-identical
between the two forms, and the macro ROM fires bullets correctly in Mesen2.
No code change — recorded the investigation so the false footgun is closed.

**`61141f6` — P1-3: SA-1 SIWP/CIWP polarity documented honestly**
The wiki/fullsnes say `$2229` bit=1 protects (so `$00` = writable); Mesen2
(our accuracy reference) and snes9x behave the opposite ($FF = writable).
Flipping to `$00` *broke* SA-1 in Mesen2, so crt0 keeps `$FF` (bytes
unchanged, comments only) and the docs now present the conflict instead of
asserting a polarity. Stale refs fixed.

**`57a8550` — P1-2: bank $00 budget investigation**
The uniform "12 bytes free" alarm is partly a symmap artifact (force-emit
anchors land in vector-table gaps; the metric measures to `0x10000`, not the
header ceiling). Silent-corruption is still correctly gated by the separate
spill check. Refined the B1 chantier entry.

**`ab2af2a` — B1: map data can live outside bank $00 (first milestone)**
The map scroll runtime hardcoded `DB=$00` (5 sites in `map.asm`) even though
the bank was already stored in `maptile_L1b`. Now honours it (backward
compatible). `maps/mapscroll` (25 KB map → bank 2, free 12→17093) and
`maps/tiled` (13 KB → bank 2, free 12→10346) moved out of bank $00,
pixel-identical in visual regression. Scoping result documented: the
C-pointer-deref examples need a compiler codegen fix first.

## Validation
- `make clean && make` clean; `make lint-docs` / `make lint-asm-abi` green.
- Quick suite **293/293** at every step.
- Mesen2: `sa1_hello` + `sa1_starfield` boot to `sa1_status=$A5`.

## Notes
A themed batch of review follow-ups rather than one topic; commits are
independent and can be reviewed/split if preferred. Remaining work (B1
compiler sub-chantier, ratchet re-tune, P2 findings) tracked in
`.claude/STRUCTURAL_DEFECTS.md`.