### PR TITLE
chore: retire opensnes-emu refs from the test hooks (luna-only)

### DIFF
--- a/.claude/hooks/mark-tests-passed.sh
+++ b/.claude/hooks/mark-tests-passed.sh
@@ -2,12 +2,9 @@
 # Post-test marker hook for Claude Code
 # Creates a daily marker file when the OpenSNES test suite completes successfully.
 #
-# Watched commands : `node ... run-all-tests.mjs ...` (canonical test runner)
-# Success patterns : `ALL CHECKS PASSED` (output of run-all-tests.mjs)
-#
-# Legacy patterns (run_tests.sh / validate_examples.sh / "All tests passed" /
-# "ALL VALIDATIONS PASSED") are still matched for backwards compatibility,
-# even though those scripts no longer ship with the repo.
+# Watched command  : `make tests` (the luna suite).
+# Success pattern  : `ALL CHECKS PASSED` (emitted by the `tests` make target
+#                    only after coverage + visual regression + probes all pass).
 
 # No set -euo pipefail — this hook must NEVER crash.
 
@@ -15,7 +12,7 @@ INPUT=$(cat 2>/dev/null) || INPUT=""
 
 # Quick exit if not about a test command
 case "$INPUT" in
-    *run-all-tests.mjs*|*run_tests.sh*|*validate_examples.sh*) ;;
+    *make\ tests*|*make\ \ tests*|*luna_runner.py*|*run_all.py*) ;;
     *)
         exit 0
         ;;
@@ -32,8 +29,8 @@ except:
     print('')
 " 2>/dev/null) || OUTPUT=""
 
-# Check for success indicators (current + legacy)
-if echo "$OUTPUT" | grep -qE 'ALL CHECKS PASSED|All tests passed|ALL VALIDATIONS PASSED' 2>/dev/null; then
+# Check for the success banner emitted by `make tests`
+if echo "$OUTPUT" | grep -qE 'ALL CHECKS PASSED' 2>/dev/null; then
     TODAY=$(date +%Y-%m-%d)
     MARKER="/tmp/opensnes_tests_passed_${TODAY}"
     echo "$(date '+%H:%M:%S') tests passed" >> "$MARKER" 2>/dev/null

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -30,6 +30,6 @@ fi
 
 # Tests not run today — block
 cat <<'EOF'
-{"decision": "block", "reason": "BLOCKED: OpenSNES test suite has not been run today.\n\nRun the test suite first:\n\n  cd tools/opensnes-emu && node test/run-all-tests.mjs --quick\n\nIf all checks pass, the marker /tmp/opensnes_tests_passed_$(date +%Y-%m-%d) is created automatically.\n\nTo bypass for trivial changes (docs, comments), touch the marker manually:\n\n  touch /tmp/opensnes_tests_passed_$(date +%Y-%m-%d)\n\nSee CONTRIBUTING.md for the full testing workflow."}
+{"decision": "block", "reason": "BLOCKED: OpenSNES test suite has not been run today.\n\nRun the test suite first (single tool: luna):\n\n  make tests\n\nWhen it prints 'ALL CHECKS PASSED' the marker /tmp/opensnes_tests_passed_$(date +%Y-%m-%d) is created automatically.\n\nTo bypass for trivial changes (docs, comments), touch the marker manually:\n\n  touch /tmp/opensnes_tests_passed_$(date +%Y-%m-%d)\n\nSee CONTRIBUTING.md for the full testing workflow."}
 EOF
 exit 0

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ tests: test-compiler
 	@python3 tools/luna-test/luna_runner.py --coverage
 	@python3 tools/luna-test/luna_runner.py --compare
 	@python3 tools/luna-test/probes/run_all.py
+	@echo "ALL CHECKS PASSED (luna)"
 
 # Compile-time cc65816 C→ASM pattern checks (no emulator needed).
 test-compiler:


### PR DESCRIPTION
Last snes9x/Node leftovers in the dev workflow. After the luna migration the two
Claude Code hooks still referenced the removed `tools/opensnes-emu` Node runner:

- **`.claude/hooks/pre-commit-check.sh`** — block message said to run
  `cd tools/opensnes-emu && node test/run-all-tests.mjs`. Now: `make tests`.
- **`.claude/hooks/mark-tests-passed.sh`** — watched that runner's output, so the
  daily test marker stopped auto-creating post-migration (manual `touch` needed).
  Now watches `make tests` / the luna drivers.
- **`Makefile`** — `tests` target emits a final `ALL CHECKS PASSED (luna)` banner
  (reached only after coverage + visual regression + probes pass) as the marker
  hook's success signal.

After this, **luna is the only test backend referenced anywhere in the repo**
(verified: no snes9x/wasm/emscripten/node/mesen2/.mjs in any tracked build/CI/
test/hook file). Remaining mentions live only in `.claude/STRUCTURAL_DEFECTS.md`
(historical maintainer strategy log — separate doc-debt, not a tool).