### PR TITLE
test(compiler): A7 Phase 0 — 32-bit runtime harness (finds an Osar fold bug)

### DIFF
--- a/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
+++ b/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
@@ -106,6 +106,49 @@ rules).
 - Update `KNOWN_LIMITATIONS.md` (severity drops on the bank-`$00` and RAM-`$2000`
   entries); close **B1/B3/B4 in the catalogue as "subsumed by A6"**, mark B2 done.
 
+## 3b. Phase 0 OUTCOME (2026-06-22) — A7 is far more done than the catalogue says
+
+**Audit.** The QBE w65816 backend already implements the `Kl` class broadly —
+`Oload`/`Ostore`/`Ostorel`, `Oadd`/`Osub` (carry chains), `Omul` (`__mul32`),
+`Odiv`/`Oudiv`/`Orem`/`Ourem` (`tcc_sdivmod32`/`tcc_udivmod32`), `Oshl`/`Oshr`/
+`Osar` (pair sequences), `Oneg`/`Oand`/`Oor`/`Oxor`, comparisons, plus high-half
+dead/zero optimization pre-passes. The catalogue's premise ("never extended past
+16-bit", "NOT yet attempted") is **stale** — prior chantiers (incl. fix32 v0.21.0)
+did the bulk. **A7's remaining work is verification + edge-case fixes, not a
+from-scratch implementation.**
+
+**Runtime harness built** — `devtools/compiler-tests/runtime/a7_32bit/`
+(`main.c` + `Makefile` + `test_a7_32bit.py`): a ROM computing 13 s32/u32 ops into
+WRAM globals, checked via `luna state --assert`. Run:
+`cd devtools/compiler-tests/runtime/a7_32bit && make && python3 test_a7_32bit.py`.
+**Result: 12/13 correct, 1 real bug (xfail'd).** This is the permanent A7 gate —
+the static C→ASM checks pass even on the broken case, so only this catches it.
+
+**The one real bug (= A7 Phase 1 scope):**
+`(s32)-256 >> 4` folds to `0x0FFFFFF0` instead of `0xFFFFFFF0`. Root cause is
+**not the codegen** (the `Osar Kl` emit path looks correct) but the **constant
+folder**: `compiler/qbe/fold.c:80`
+`case Osar: x = (w ? l.s : (int32_t)l.s) >> (r.u & (31|w<<5));`
+On w65816 `Kl` is **32-bit**, but QBE folds it as 64-bit (`w==1` → `l.s`,
+64-bit). A negative 32-bit constant is stored in the 64-bit `con` **without
+sign-extension** (`0x00000000FFFFFF00`), so the 64-bit arithmetic `>>` fills from
+bit 63 (=0). `Oshr` (logical) survives because logical-shifting a zero-extended
+value gives the right low-32; only sign-dependent folds break.
+
+**Latent siblings (verify in Phase 1):** the same non-sign-extended-con issue
+affects **signed `Kl` divide/mod and signed comparisons** on negative 32-bit
+constants — add cases to the harness before fixing.
+
+**Phase 1 fix options (decide before coding — Class A, fold pass is delicate):**
+- **(A) sign-extend 32-bit constants into the 64-bit `con` at materialization** —
+  fixes Osar + signed div/cmp at the source, keeps `fold.c` generic. More
+  invasive (find the Kl-constant build path); broadest correctness.
+- **(B) make `fold.c` treat `Kl` as 32-bit on this fork** (`(int32_t)l.s` for
+  Osar, mask others to 32-bit) — localized, matches the backend's Kl=32-bit
+  reality, but touches generic QBE core and must be swept across every Kl fold.
+- Either way: extend the harness (signed div/cmp), then fix, then gate green,
+  then revisit B5's "blocked by A7" note (already shipped) and ship A7 as a patch.
+
 ## 4. Test strategy (luna, not the removed bridge)
 
 The catalogue's acceptance criteria predate the luna migration and reference

--- a/devtools/compiler-tests/runtime/a7_32bit/Makefile
+++ b/devtools/compiler-tests/runtime/a7_32bit/Makefile
@@ -1,0 +1,11 @@
+OPENSNES := $(shell cd ../../../.. && pwd)
+
+TARGET   := a7_32bit.sfc
+ROM_NAME := A7 32BIT TEST
+
+USE_LIB  := 1
+LIB_MODULES := console sprite dma background
+
+CSRC := main.c
+
+include $(OPENSNES)/make/common.mk

--- a/devtools/compiler-tests/runtime/a7_32bit/main.c
+++ b/devtools/compiler-tests/runtime/a7_32bit/main.c
@@ -1,0 +1,55 @@
+/*
+ * A7 runtime-correctness fixture — 32-bit (s32/u32, QBE Kl class) arithmetic.
+ *
+ * Computes a battery of 32-bit operations into WRAM globals, which the harness
+ * (test_a7_32bit.py, via `luna state --assert`) checks against the expected
+ * values. This is the RUNTIME gate the A7 chantier needs: the static C->ASM
+ * pattern checks pass even on a half-correct Kl implementation, so only an
+ * actual execution check proves the codegen.
+ *
+ * Globals live in bank $00 WRAM (< $2000), so `--assert 00:<off>=<bytes>` reads
+ * them. u32 is little-endian: value V -> bytes V&FF, V>>8, V>>16, V>>24.
+ */
+#include <snes.h>
+
+/* Results — kept as explicit u32/s32/u16 so each Kl op path is exercised. */
+u32 r_add;     /* 0x0000FFFF + 1            -> 0x00010000 (carry low->high) */
+u32 r_sub;     /* 0x00010000 - 1            -> 0x0000FFFF (borrow high->low) */
+u32 r_mul;     /* 0x00001234 * 0x10         -> 0x00012340 */
+u32 r_mulhi;   /* 0x00010000 * 0x10         -> 0x00100000 (result in high half) */
+u32 r_shl;     /* 1u << 20                  -> 0x00100000 */
+u32 r_shr;     /* 0x80000000 >> 4 (logical) -> 0x08000000 */
+u32 r_sar;     /* (s32)-256 >> 4 (arith)    -> 0xFFFFFFF0 */
+u32 r_div;     /* 0x00100000 / 0x10         -> 0x00010000 */
+u32 r_mod;     /* 0x00100003 % 0x10         -> 0x00000003 */
+u32 r_and;     /* 0x0F0F0F0F & 0x00FFFF00   -> 0x000F0F00 */
+u32 r_or;      /* 0x0F0F0F0F | 0x00FFFF00   -> 0x0FFFFF0F */
+u32 r_xor;     /* 0x0F0F0F0F ^ 0x00FFFF00   -> 0x0FF0F00F */
+u16 r_cmp;     /* (0x10000u > 0xFFFFu)      -> 1 (high-half-aware compare) */
+
+int main(void) {
+    u32 a, b;
+    s32 s;
+
+    a = 0x0000FFFFu; r_add = a + 1u;
+    a = 0x00010000u; r_sub = a - 1u;
+    a = 0x00001234u; r_mul = a * 0x10u;
+    a = 0x00010000u; r_mulhi = a * 0x10u;
+    a = 1u; r_shl = a << 20;   /* a is u32 — shift the 32-bit operand, not a 16-bit `1u` */
+    a = 0x80000000u; r_shr = a >> 4;
+    s = -256;        r_sar = (u32)(s >> 4);
+    a = 0x00100000u; r_div = a / 0x10u;
+    a = 0x00100003u; r_mod = a % 0x10u;
+    a = 0x0F0F0F0Fu; b = 0x00FFFF00u;
+    r_and = a & b;
+    r_or  = a | b;
+    r_xor = a ^ b;
+    r_cmp = (0x00010000u > 0x0000FFFFu) ? 1u : 0u;
+
+    consoleInit();
+    setScreenOn();
+    while (1) {
+        WaitForVBlank();
+    }
+    return 0;
+}

--- a/devtools/compiler-tests/runtime/a7_32bit/test_a7_32bit.py
+++ b/devtools/compiler-tests/runtime/a7_32bit/test_a7_32bit.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Runtime-correctness check for A7 (32-bit Kl codegen).
+
+Builds nothing — assumes `make` produced a7_32bit.sfc. Resolves each result
+global from the .sym and asserts its WRAM value via `luna state --assert`. This
+is the gate the A7 chantier needs (static C->ASM checks can't prove runtime
+correctness of 32-bit arithmetic).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[3]
+sys.path.insert(0, str(REPO / "tools" / "luna-test" / "probes"))
+from lib import find_luna, sym_of, assert_mem  # noqa: E402
+
+ROM = HERE / "a7_32bit.sfc"
+STEPS = 1_000_000
+
+# (global, width-bytes, expected-value)
+CASES = [
+    ("r_add",   4, 0x00010000),
+    ("r_sub",   4, 0x0000FFFF),
+    ("r_mul",   4, 0x00012340),
+    ("r_mulhi", 4, 0x00100000),
+    ("r_shl",   4, 0x00100000),
+    ("r_shr",   4, 0x08000000),
+    ("r_sar",   4, 0xFFFFFFF0),
+    ("r_div",   4, 0x00010000),
+    ("r_mod",   4, 0x00000003),
+    ("r_and",   4, 0x000F0F00),
+    ("r_or",    4, 0x0FFFFF0F),
+    ("r_xor",   4, 0x0FF0F00F),
+    ("r_cmp",   2, 0x0001),
+]
+
+
+def le_bytes(value: int, width: int) -> str:
+    return "".join(f"{(value >> (8 * i)) & 0xFF:02X}" for i in range(width))
+
+
+# Known-failing cases (xfail) — documented A7 bugs not yet fixed. Remove an entry
+# when its fix lands; an unexpected PASS (XPASS) then flags the stale xfail.
+#   r_sar: QBE constant-fold of `Osar` on a Kl (32-bit-on-w65816) value uses
+#          64-bit arithmetic on a NON-sign-extended con, so arithmetic-shift-right
+#          of a negative 32-bit constant fills from bit 63 (=0) instead of bit 31.
+#          Root cause: compiler/qbe/fold.c:80. Same class is latent for signed
+#          Kl divide/compare on negative constants. Fix = chantier A7 Phase 1.
+KNOWN_FAIL = {"r_sar"}
+
+
+def run() -> int:
+    if not ROM.is_file():
+        sys.exit(f"ROM missing: {ROM} (run `make` first)")
+    luna = find_luna()
+    real_fails = 0
+    for name, width, want in CASES:
+        bank, off = sym_of(ROM, name)
+        ok, detail = assert_mem(luna, ROM, STEPS, [(bank, off, le_bytes(want, width))])
+        if name in KNOWN_FAIL:
+            if ok:
+                print(f"  XPASS {name} == 0x{want:0{width*2}X}  ← fixed! remove from KNOWN_FAIL")
+                real_fails += 1
+            else:
+                print(f"  XFAIL {name} == 0x{want:0{width*2}X}  (known A7 bug, see header)")
+        elif ok:
+            print(f"  PASS  {name} == 0x{want:0{width*2}X}")
+        else:
+            print(f"  FAIL  {name} == 0x{want:0{width*2}X}  [{detail}]")
+            real_fails += 1
+    passed = sum(1 for n, _, _ in CASES if n not in KNOWN_FAIL)
+    print(f"\nA7 32-bit runtime: {passed - real_fails}/{passed} ok"
+          f" (+{len(KNOWN_FAIL)} xfail: {', '.join(sorted(KNOWN_FAIL))})")
+    return 1 if real_fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
A7 chantier, Phase 0 (no compiler code changed — pure diagnostic + gate).

**Audit finding:** the QBE w65816 backend already implements `Kl` (32-bit) broadly
— the catalogue's "never extended past 16-bit" is stale. A7 = verify + fix edges,
not a rewrite.

**New runtime-correctness harness** `devtools/compiler-tests/runtime/a7_32bit/`
(ROM + `luna state --assert`): 13 s32/u32 cases. **12/13 correct, 1 real bug
(xfail'd).** Run: `cd devtools/compiler-tests/runtime/a7_32bit && make && python3
test_a7_32bit.py` → exit 0 (the xfail keeps it green until fixed).

**The bug (Phase 1 scope):** `(s32)-256 >> 4` → `0x0FFFFFF0` not `0xFFFFFFF0`.
Root cause is the **constant folder**, not codegen: `compiler/qbe/fold.c:80` folds
`Osar` on `Kl` as 64-bit, but a negative 32-bit constant isn't sign-extended into
the 64-bit `con` → the arithmetic shift fills from bit 63 (=0). Signed `Kl`
divide/compare on negative constants are latent siblings.

Not wired into the blocking CI yet (xfail). Plan §3b has the full finding + two
fix options for the maintainer.