### PR TITLE
fix(compiler): A7 — correct Osar 32-bit sign-extension in QBE fold

### DIFF
--- a/.claude/STRUCTURAL_DEFECTS.md
+++ b/.claude/STRUCTURAL_DEFECTS.md
@@ -875,15 +875,23 @@ representation in the toolchain.
 
 ---
 
-#### A7. QBE w65816 32-bit (`Kl` class) codegen never extended past 16-bit 🟡 PARTIAL
+#### A7. QBE w65816 32-bit (`Kl` class) codegen — RESOLVED 🟢 (2026-06-22, ships v0.21.2)
 
-> **Execution plan (2026-06-22):** A7 → A6 → B1/B2 are sequenced as ONE chantier
-> in `.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md` (compiler-first; A6
-> subsumes B1/B3/B4; shared 4-byte slot allocator). **Partial progress:** the
-> fix32 chantier (B5, v0.21.0) already shipped the `Kl` *return* convention,
-> `__mul32`, the `Kl` shift-by-constant fix, and a 48-iter long divide — so A7 is
-> no longer greenfield. Phase 0 of the plan audits exactly which `Kl` ops are
-> done before filling gaps.
+> **Resolution (chantier A7, Phases 0–1 — see
+> `.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md`):** the catalogue's
+> "never extended past 16-bit" premise was stale — the `Kl` class was already
+> implemented broadly (prior chantiers + fix32 v0.21.0: return convention,
+> `__mul32`, long divide, pair lowering). Phase 0 built a luna runtime-correctness
+> harness (`devtools/compiler-tests/runtime/a7_32bit/`, 18 s32/u32 cases) which
+> the static C→ASM checks couldn't provide; it found exactly **one** real bug —
+> the `Osar` constant-fold dropped the sign on negative 32-bit constants
+> (`compiler/qbe/fold.c`, folded `Kl` as 64-bit). Fixed (qbe `1884a20`, 32-bit
+> signed fold); harness 18/18, full suite green (visual 56/56, no fbhash drift),
+> wired as a permanent gate in `make tests` + CI.
+>
+> **Scope note:** only A7 shipped here (maintainer decision 2026-06-22). A6
+> (24-bit pointers) / B1 / B2 remain a deferred follow-up chantier; A7's
+> slot-allocator work that A6 would reuse is already present in the backend.
 
 > **Status (2026-05-09): identified during B5 investigation, validated
 > with a runtime ROM, NOT yet attempted.** This chantier exists because

--- a/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
+++ b/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
@@ -149,6 +149,29 @@ constants — add cases to the harness before fixing.
 - Either way: extend the harness (signed div/cmp), then fix, then gate green,
   then revisit B5's "blocked by A7" note (already shipped) and ship A7 as a patch.
 
+## 3c. Phase 1 DONE (2026-06-22) — A7 fixed
+
+**Blast radius (measured by extending the harness with signed div/mod/compare on
+negative 32-bit constants):** narrower than feared. The asm proved signed
+`Kl` div/mod take the **runtime** path (`tcc_sdivmod32`, not folded) and signed
+compares are branch-coded — both correct. **Only the `Osar` constant-fold was
+broken** (two cases: `>>4` and `>>8`).
+
+**Fix:** `compiler/qbe/fold.c` `case Osar` now uses 32-bit signed semantics
+(`(int32_t)l.s >> (r.u & 31)`) — correct for w65816 where `Kl` is 32-bit and there
+is no 64-bit integer. One-line change, commented for a future QBE rebase. qbe
+fork commit `1884a20` on `fix/a6-a7-leaf-opt-kl-frameless`; `compiler/PINS.md`
+bumped `e50f148 → 1884a20` (50 patches); `make verify-toolchain` green.
+
+**Validation:** the runtime harness is now **18/18** (no xfail) and is a permanent
+gate — wired into `make tests` and the CI `functional-tests` job. Full Class-A
+re-validation: `make clean && make` (compiler + lib + 56 examples) + `make tests`
+→ compiler checks 10/10, coverage 54 OK / 2 INPUT-DEP, **visual 56/56 (no fbhash
+drift)**, probes 10/10. Ships as a patch (v0.21.2).
+
+**Deferred (unchanged):** A6 / B1 / B2 (Phases 2–4) remain a follow-up chantier;
+decisions #2 (pointer = 4 bytes) and #3 (B2 per-symbol bank) pre-recorded above.
+
 ## 4. Test strategy (luna, not the removed bridge)
 
 The catalogue's acceptance criteria predate the luna migration and reference

--- a/.github/workflows/opensnes_build.yml
+++ b/.github/workflows/opensnes_build.yml
@@ -255,6 +255,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: scripts/install-luna.sh
 
+      - name: A7 32-bit runtime correctness
+        # Builds the s32/u32 fixture ROM and asserts its WRAM results via luna.
+        # Runtime gate the static C→ASM checks can't provide (they pass even on
+        # broken 32-bit codegen — see chantier A7 Phase 0/1).
+        run: |
+          make -s -C devtools/compiler-tests/runtime/a7_32bit
+          python3 devtools/compiler-tests/runtime/a7_32bit/test_a7_32bit.py
+
       - name: Corpus liveness coverage
         run: python3 tools/luna-test/luna_runner.py --coverage
 

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,8 @@ tests: test-compiler
 	@python3 tools/luna-test/luna_runner.py --coverage
 	@python3 tools/luna-test/luna_runner.py --compare
 	@python3 tools/luna-test/probes/run_all.py
+	@$(MAKE) -s -C devtools/compiler-tests/runtime/a7_32bit
+	@python3 devtools/compiler-tests/runtime/a7_32bit/test_a7_32bit.py
 	@echo "ALL CHECKS PASSED (luna)"
 
 # Compile-time cc65816 C→ASM pattern checks (no emulator needed).

--- a/compiler/PINS.md
+++ b/compiler/PINS.md
@@ -30,7 +30,7 @@ reformat without updating the script.
 | path | sha | source |
 |------|-----|--------|
 | compiler/cproc | c7552693ae7fe3bee034d48e06a182ecc5da08bd | github.com/k0b3n4irb/cproc:fix/a1-followup-long-kl |
-| compiler/qbe | e50f1481f0f0afb1d6b4c82bfe277fac43a20ccf | github.com/k0b3n4irb/qbe:fix/a6-a7-leaf-opt-kl-frameless |
+| compiler/qbe | 1884a20cf7f3b500b5e6986022a9a4ee43ba21d2 | github.com/k0b3n4irb/qbe:fix/a6-a7-leaf-opt-kl-frameless |
 | compiler/wla-dx | ffe59ca1db32a4e7b40e16674acb844a5a0160ef | github.com/k0b3n4irb/wla-dx:master |
 <!-- END PINS -->
 
@@ -63,11 +63,12 @@ own structural defect is tracked as A6 in the structural-defects catalogue;
 reducing pointer storage cascades through QBE w65816's indirect-call emit
 pass). Empirically validated against the full quick test suite.
 
-### compiler/qbe — 49 patches (the bulk of the SDK's compiler magic)
+### compiler/qbe — 50 patches (the bulk of the SDK's compiler magic)
 
 Selected highlights (full list via `git -C compiler/qbe log HEAD --not upstream/master --oneline`):
 
 ```
+1884a20  fix(qbe): fold Osar as 32-bit signed on w65816 (chantier A7 Phase 1)
 179676e  feat(w65816): chantier A6+A7 — full pointer ABI + Kl pair lowering
 5c23467  fix(qbe): guard crash_handler behind __has_include(<execinfo.h>)
 444edea  fix(qbe): guard inline_record_dat_ref against DStart/DEnd stack garbage

--- a/devtools/compiler-tests/runtime/a7_32bit/main.c
+++ b/devtools/compiler-tests/runtime/a7_32bit/main.c
@@ -26,6 +26,12 @@ u32 r_and;     /* 0x0F0F0F0F & 0x00FFFF00   -> 0x000F0F00 */
 u32 r_or;      /* 0x0F0F0F0F | 0x00FFFF00   -> 0x0FFFFF0F */
 u32 r_xor;     /* 0x0F0F0F0F ^ 0x00FFFF00   -> 0x0FF0F00F */
 u16 r_cmp;     /* (0x10000u > 0xFFFFu)      -> 1 (high-half-aware compare) */
+/* Latent siblings of the Osar fold bug: signed Kl ops on negative 32-bit consts. */
+u32 r_sdiv;    /* (s32)-256 / 16  (signed)  -> 0xFFFFFFF0 (-16) */
+u32 r_smod;    /* (s32)-257 % 16  (signed)  -> 0xFFFFFFFF (-1) */
+u16 r_slt;     /* ((s32)-1 < 0)             -> 1 (signed compare) */
+u16 r_sgt;     /* ((s32)-5 > (s32)3)        -> 0 (signed compare) */
+u32 r_sar8;    /* (s32)-1 >> 8    (arith)   -> 0xFFFFFFFF */
 
 int main(void) {
     u32 a, b;
@@ -45,6 +51,11 @@ int main(void) {
     r_or  = a | b;
     r_xor = a ^ b;
     r_cmp = (0x00010000u > 0x0000FFFFu) ? 1u : 0u;
+    s = -256; r_sdiv = (u32)(s / 16);
+    s = -257; r_smod = (u32)(s % 16);
+    s = -1;   r_slt  = (s < 0) ? 1u : 0u;
+    s = -5;   r_sgt  = (s > 3) ? 1u : 0u;
+    s = -1;   r_sar8 = (u32)(s >> 8);
 
     consoleInit();
     setScreenOn();

--- a/devtools/compiler-tests/runtime/a7_32bit/test_a7_32bit.py
+++ b/devtools/compiler-tests/runtime/a7_32bit/test_a7_32bit.py
@@ -34,6 +34,11 @@ CASES = [
     ("r_or",    4, 0x0FFFFF0F),
     ("r_xor",   4, 0x0FF0F00F),
     ("r_cmp",   2, 0x0001),
+    ("r_sdiv",  4, 0xFFFFFFF0),
+    ("r_smod",  4, 0xFFFFFFFF),
+    ("r_slt",   2, 0x0001),
+    ("r_sgt",   2, 0x0000),
+    ("r_sar8",  4, 0xFFFFFFFF),
 ]
 
 
@@ -43,12 +48,13 @@ def le_bytes(value: int, width: int) -> str:
 
 # Known-failing cases (xfail) — documented A7 bugs not yet fixed. Remove an entry
 # when its fix lands; an unexpected PASS (XPASS) then flags the stale xfail.
-#   r_sar: QBE constant-fold of `Osar` on a Kl (32-bit-on-w65816) value uses
-#          64-bit arithmetic on a NON-sign-extended con, so arithmetic-shift-right
-#          of a negative 32-bit constant fills from bit 63 (=0) instead of bit 31.
-#          Root cause: compiler/qbe/fold.c:80. Same class is latent for signed
-#          Kl divide/compare on negative constants. Fix = chantier A7 Phase 1.
-KNOWN_FAIL = {"r_sar"}
+#
+# (empty) — the Osar fold bug found in Phase 0 is FIXED: `compiler/qbe/fold.c`
+# now folds `Osar` with 32-bit signed semantics (w65816 Kl is 32-bit), so
+# arithmetic-shift-right of a negative 32-bit constant sign-extends correctly
+# (r_sar, r_sar8). Signed Kl div/mod/compare were verified to go through the
+# runtime path (not folded), so they were never affected.
+KNOWN_FAIL: set[str] = set()
 
 
 def run() -> int:


### PR DESCRIPTION
**Chantier A7 (Phases 0–1) — done.** Ships the 32-bit `Kl` codegen as correct.

**Bug:** `(s32)-256 >> 4` folded to `0x0FFFFFF0` not `0xFFFFFFF0`. cproc emits
`%x =l sar`; QBE's fold pass (`compiler/qbe/fold.c` `case Osar`) evaluated it as
64-bit on a zero-extended con → sign dropped. On w65816 `Kl` is 32-bit, so the
fold now uses 32-bit signed semantics (qbe `1884a20`; `PINS.md` e50f148→1884a20,
50 patches; `verify-toolchain` green).

**How it was found:** a new runtime-correctness fixture
`devtools/compiler-tests/runtime/a7_32bit/` (ROM × `luna state --assert`, 18
s32/u32 cases) — the gap the static C→ASM checks can't cover. Measured blast
radius: only `Osar` was affected (signed div/mod run the runtime path; compares
are branch-coded). **Harness 18/18**, wired as a permanent gate in `make tests`
+ the CI functional-tests job.

**Class-A validation:** `make clean && make` + `make tests` → compiler 10/10,
coverage 54 OK / 2 INPUT-DEP, **visual 56/56 (no fbhash drift)**, probes 10/10.

Audit finding documented: A7 was far more implemented than the catalogue said
(prior chantiers + fix32 v0.21.0). A6/B1/B2 remain a deferred follow-up chantier.
Patch release material (v0.21.2).