### PR TITLE
release: v0.21.2

### DIFF
--- a/.claude/STRUCTURAL_DEFECTS.md
+++ b/.claude/STRUCTURAL_DEFECTS.md
@@ -875,15 +875,23 @@ representation in the toolchain.
 
 ---
 
-#### A7. QBE w65816 32-bit (`Kl` class) codegen never extended past 16-bit 🟡 PARTIAL
+#### A7. QBE w65816 32-bit (`Kl` class) codegen — RESOLVED 🟢 (2026-06-22, ships v0.21.2)
 
-> **Execution plan (2026-06-22):** A7 → A6 → B1/B2 are sequenced as ONE chantier
-> in `.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md` (compiler-first; A6
-> subsumes B1/B3/B4; shared 4-byte slot allocator). **Partial progress:** the
-> fix32 chantier (B5, v0.21.0) already shipped the `Kl` *return* convention,
-> `__mul32`, the `Kl` shift-by-constant fix, and a 48-iter long divide — so A7 is
-> no longer greenfield. Phase 0 of the plan audits exactly which `Kl` ops are
-> done before filling gaps.
+> **Resolution (chantier A7, Phases 0–1 — see
+> `.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md`):** the catalogue's
+> "never extended past 16-bit" premise was stale — the `Kl` class was already
+> implemented broadly (prior chantiers + fix32 v0.21.0: return convention,
+> `__mul32`, long divide, pair lowering). Phase 0 built a luna runtime-correctness
+> harness (`devtools/compiler-tests/runtime/a7_32bit/`, 18 s32/u32 cases) which
+> the static C→ASM checks couldn't provide; it found exactly **one** real bug —
+> the `Osar` constant-fold dropped the sign on negative 32-bit constants
+> (`compiler/qbe/fold.c`, folded `Kl` as 64-bit). Fixed (qbe `1884a20`, 32-bit
+> signed fold); harness 18/18, full suite green (visual 56/56, no fbhash drift),
+> wired as a permanent gate in `make tests` + CI.
+>
+> **Scope note:** only A7 shipped here (maintainer decision 2026-06-22). A6
+> (24-bit pointers) / B1 / B2 remain a deferred follow-up chantier; A7's
+> slot-allocator work that A6 would reuse is already present in the backend.
 
 > **Status (2026-05-09): identified during B5 investigation, validated
 > with a runtime ROM, NOT yet attempted.** This chantier exists because

--- a/.claude/STRUCTURAL_DEFECTS.md
+++ b/.claude/STRUCTURAL_DEFECTS.md
@@ -875,7 +875,15 @@ representation in the toolchain.
 
 ---
 
-#### A7. QBE w65816 32-bit (`Kl` class) codegen never extended past 16-bit 🔴
+#### A7. QBE w65816 32-bit (`Kl` class) codegen never extended past 16-bit 🟡 PARTIAL
+
+> **Execution plan (2026-06-22):** A7 → A6 → B1/B2 are sequenced as ONE chantier
+> in `.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md` (compiler-first; A6
+> subsumes B1/B3/B4; shared 4-byte slot allocator). **Partial progress:** the
+> fix32 chantier (B5, v0.21.0) already shipped the `Kl` *return* convention,
+> `__mul32`, the `Kl` shift-by-constant fix, and a 48-iter long divide — so A7 is
+> no longer greenfield. Phase 0 of the plan audits exactly which `Kl` ops are
+> done before filling gaps.
 
 > **Status (2026-05-09): identified during B5 investigation, validated
 > with a runtime ROM, NOT yet attempted.** This chantier exists because
@@ -1466,7 +1474,16 @@ bridge that reads the actual symbol bank at link time.
 
 ---
 
-#### B5. No `fixed32` (16.16) in `<snes/math.h>` 🟡
+#### B5. No `fixed32` (16.16) in `<snes/math.h>` — RESOLVED 🟢 (v0.21.0, 2026-06-21)
+
+**Resolution (chantier B5, v0.21.0)**: shipped `<snes/fixed32.h>` (a dedicated
+header rather than folding into `math.h`) with the full 16.16 helper set —
+`fix32Mul`, `fix32Div` (48-iteration long divide), `fix32Sin`/`fix32Cos`,
+`fix32Lerp`, `fix32Abs`, `fix32Clamp`, `fix32Min`/`fix32Max` — backed by the new
+compiler `Kl` (32-bit-class) return convention. Examples `fix32_orbit` (B5
+capstone) and `aim_target` demonstrate it. B6 (`ease_in_quad`/`ease_out_quad`
+LUTs) shipped alongside. All B5 acceptance criteria met. Original entry preserved
+below as the investigation log.
 
 **Symptom**: the lib's `fixed` type is 8.8 (`s16`), with integer range
 −128 to +127. For game state that needs higher range (e.g., a player

--- a/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
+++ b/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
@@ -1,6 +1,8 @@
 # Chantier — Full 32-bit codegen + 24-bit pointers (A7 → A6 → B1/B2)
 
-**Status:** PLANNED (2026-06-22) · **Owner:** TBD · **Risk:** High · **Effort:** ~6–10 weeks
+**Status:** A7 SCOPED (2026-06-22) — immediate scope is **A7 only** (Phases 0–1,
+ships as a patch); A6/B1/B2 (Phases 2–4) deferred to a follow-up chantier. See §7.
+· **Owner:** TBD · **Risk:** High (A7 alone: Medium) · **Effort:** A7 ≈ 2 weeks; full thread ~6–10
 **Catalogue entries:** `.claude/STRUCTURAL_DEFECTS.md` A7, A6, B1, B2 (per-item
 symptom/root-cause/acceptance live there; this doc is the *sequencing & execution*
 plan that ties them into one chantier).
@@ -137,15 +139,41 @@ important deliverable of Phase 0.
 - One CHANGELOG section (likely a minor bump, e.g. v0.22.0) covering the unblock:
   "assets and C RAM are no longer confined to bank `$00` / below `$2000`."
 
-## 7. Open questions for the maintainer
+## 7. Decisions (maintainer, 2026-06-22)
 
-1. **One chantier or staged releases?** A7 alone (Phase 1) is shippable as a patch
-   (finishes 32-bit math). A6+B1+B2 is the bigger minor. Ship A7 first, or hold all
-   for one v0.22.0?
-2. **Pointer size 4 vs 3 bytes** — the catalogue picks 4 (alignment sanity, dead
-   high byte). Confirm before Phase 2 (it's expensive to change later).
-3. **B2 emit:** per-symbol bank detection vs always-explicit-bank for RAM (simpler,
-   ~1 cycle/access). Recommend always-explicit unless a hot-path benchmark objects.
+1. **Scope: A7 ONLY for now.** Do Phase 0 + Phase 1 (finish 32-bit `Kl` codegen)
+   and ship it as a **patch** release. **A6, B1, B2 are deferred** to a separate
+   follow-up chantier (a later minor, e.g. v0.22.0) — this doc keeps their phases
+   (2–4) as the pre-written plan for when that chantier opens. Immediate scope
+   below collapses to Phases 0–1.
+
+2. **Pointer size = 4 bytes** (decided for A6, not needed for A7). Rationale: the
+   65816 has no 3-byte load — a pointer is always read as a 16-bit word + a bank
+   byte, so 3 vs 4 doesn't change access cost; 4 aligns with `long`=4 (post-A1) so
+   mixed int/long/pointer structs stay aligned and the C.5 padding bug class stays
+   closed; the only cost is one dead byte/pointer (negligible outside large pointer
+   arrays). Revisit only if a pointer-array-heavy ROM shows real bloat.
+
+3. **B2 emit = per-symbol bank detection** (decided for B2, not needed for A7).
+   Rationale: a 24-bit RAM access costs ~1 cycle + 1 byte more than the implicit
+   bank-`$00` form; *always-explicit* would tax **every** RAM access (incl. the
+   ~99% that stay in bank `$00`) → a global perf regression. Per-symbol keeps the
+   cheap form for bank-`$00` symbols and only pays the 24-bit tax for data
+   deliberately placed high. Fall back to always-explicit only if per-symbol bank
+   tracking proves too invasive in QBE.
+
+### Immediate scope (this chantier) = Phases 0–1 only
+
+- **Phase 0** — audit current `Kl` op coverage + build the luna runtime-correctness
+  harness (the permanent gate).
+- **Phase 1** — finish the `Kl` codegen (4-byte slot allocator + remaining ops +
+  `__mul32`/`__udiv32`/`__sdiv32` gaps), runtime fixtures green, ABI/PINS updated.
+- **Ship**: a patch release ("32-bit `s32`/`u32` arithmetic is now correct
+  end-to-end"). The slot-allocator widening done here is the shared piece the
+  deferred A6 will reuse.
+
+Phases 2–4 (A6 / B2 / B1) remain documented above but are **out of scope** until
+the follow-up chantier opens; decisions #2 and #3 are pre-recorded for it.
 
 ---
 

--- a/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
+++ b/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
@@ -1,0 +1,155 @@
+# Chantier — Full 32-bit codegen + 24-bit pointers (A7 → A6 → B1/B2)
+
+**Status:** PLANNED (2026-06-22) · **Owner:** TBD · **Risk:** High · **Effort:** ~6–10 weeks
+**Catalogue entries:** `.claude/STRUCTURAL_DEFECTS.md` A7, A6, B1, B2 (per-item
+symptom/root-cause/acceptance live there; this doc is the *sequencing & execution*
+plan that ties them into one chantier).
+
+---
+
+## 1. Thesis (why this order, why one chantier)
+
+The four items are one structural thread, not four independent fixes:
+
+- **A7** = QBE w65816 only half-implements the 32-bit (`Kl`) instruction class.
+- **A6** = pointers are mis-sized in the IR and indirect calls hardcode bank `$00`.
+- **B1/B2** = the *user-visible symptoms* — "assets must live in bank `$00`" and
+  "all C RAM must live below `$2000`" — are downstream of A6/A7.
+
+Two facts from the catalogue drive the plan:
+
+1. **A6 + A7 share the slot allocator.** Both need QBE temps to allocate **4-byte
+   slots** instead of today's 2-byte default (`compiler/qbe/w65816/abi.c`). Doing
+   them as one chantier means widening the allocator **once**.
+2. **A6 subsumes B1/B3/B4.** A6's acceptance says: once the compiler emits proper
+   24-bit addressing, the lib no longer needs hand-written `*Bank` API variants —
+   bank-agnostic data "just works". So **we deliberately do NOT take the lib-led
+   path** (adding `*Bank` variants now would be throwaway work). B1 collapses from
+   "add 12–15 `*Bank` functions" to "verify subsumed + lift the constraint +
+   tighten the ratchet + update docs". Likewise B2 becomes a compiler emit change,
+   not a lib change.
+
+**Therefore: compiler-first.** Finish A7, land A6 on the shared slot work, then
+B2 (RAM emit) and B1 (lift the bank-`$00` constraint) fall out.
+
+## 2. Current state — A7 is partially shipped (do NOT treat as greenfield)
+
+The **fix32 chantier (B5, v0.21.0)** already landed part of A7:
+- the **`Kl` return convention** (32-bit results returned from C functions),
+- `__mul32` runtime (`Kl` `Omul`), with the bank-byte-drop bug fixed,
+- `Kl` shift-by-constant codegen (the `low_orig` spill fix),
+- a 48-iteration long divide (used by `fix32Div`).
+
+So A7's items 1 (slot), 3 (add/sub), 4 (shift), 6 (mul) are **at least partially**
+present. **Phase 0 must audit exactly which `Kl` ops are implemented and correct**
+before writing new code — the plan's Phase 1 fills gaps, it does not start from zero.
+
+## 3. Phases & gates
+
+Each phase ends with a **gate**: `make clean && make` + `make tests` (luna) 56/56 +
+the phase's own runtime-correctness fixtures green. No phase merges to develop until
+its gate passes. Use a `wip/32bit-*` branch per phase (squash-merge per the release
+rules).
+
+### Phase 0 — Audit + test scaffold *(~3 days)*
+- Enumerate every `Kl` opcode path in `compiler/qbe/w65816/{abi.c,emit.c}`; mark
+  implemented / partial / missing against A7's list (load/store, add/sub, shl/shr/sar,
+  neg/not/xor/and/or, mul, div/mod, comparisons).
+- **Build the runtime-correctness harness on luna** (the catalogue still references
+  the removed opensnes-emu/snes9x bridge — replace with luna). New fixtures under
+  `devtools/compiler-tests/` *or* a small ROM that computes the cases and luna
+  asserts via `--assert` on WRAM (we already have this pattern in the probes).
+  Cases: `0xFFFF+1 == 0x10000`, `(s32)-1 >> 8`, `u32` mul/div, all comparisons,
+  shifts of arbitrary amounts, pointer round-trips. **This is the gate for every
+  later phase** — the existing ASM-pattern checks would pass a half-fixed impl.
+
+### Phase 1 — A7: finish `Kl` codegen *(~1.5–2 weeks)*
+- **Slot allocator**: `Kl` temps → 4-byte slots (`abi.c`). This is the shared piece
+  A6 reuses — get it right here.
+- Fill the missing/partial `Kl` ops from the Phase-0 audit (load/store pairs,
+  add/sub carry chain, shift pair w/ shift-by-16 swap, neg/logical pairs,
+  div/mod via `__sdiv32`/`__udiv32`, two-half comparisons).
+- Gate: runtime fixtures (Phase 0) all green; `fixDiv`/`fixLerp` re-validated;
+  `compiler/ABI.md` type-size table updated; `compiler/PINS.md` records new QBE
+  patches.
+
+### Phase 2 — A6: 24-bit pointers + indirect-call bank byte *(~2–3 weeks)*
+- **cproc**: `mkpointertype()` → `size=4, align=2` (bytes 0–2 = 24-bit address,
+  byte 3 = dead padding). `compiler/cproc/type.c`.
+- **emit**: rewrite the indirect-call sequence (`compiler/qbe/w65816/emit.c`) to
+  read the bank byte from pointer storage (`lda 2,x → tcc__r9+2`) instead of the
+  hardcoded `lda #$00`; reuse the Phase-1 4-byte slots.
+- **static data**: pointer fields emit `.dl symbol` + 1 byte padding.
+- **Audits (the risky part):** the 28 QBE patches that read pointer offsets;
+  `templates/crt0.asm` indirect-call sites (`nmi_callback`, `dynamic_flush_hook`);
+  lib function-pointer setters (`nmiSet`, `sceneRun`, `gameLoopRun`,
+  `oamInitDynamicSprite`).
+- Gate: `sizeof(void*)==4`; all SA-1/SuperFX examples pass luna visual + the
+  framework examples (scene_stack, gameloop) green; **C.5 padding workaround
+  reverted** (its raison d'être disappears); `make tests` 56/56.
+
+### Phase 3 — B2: C RAM outside `$2000` *(~2 weeks, partly overlaps Phase 2)*
+- emit explicit 24-bit addressing for RAM symbols whose bank ≠ `$00` (`sta.l
+  $7E:NNNN,x`), or always-explicit-bank for RAM accepting the ~1-cycle cost.
+- linker / `memmap*.inc`: allow RAM allocation above the 8 KB band (keep
+  `$00:0000–$1FFF` recommended for hot data).
+- Gate: a regression fixture puts a struct at `$7E:2500` and round-trips r/w under
+  luna; all 56 examples still pass.
+
+### Phase 4 — B1: lift the bank-`$00` constraint (now mostly verification) *(~1 week)*
+- Confirm A6 subsumes the lib `*Bank` need: relocate a large asset to a non-`$00`
+  bank in one of the tight examples and verify it renders (no `*Bank` call).
+- Tighten `BANK0_FAIL_THRESHOLD` (target 256) now that the tight examples have
+  real headroom; update `.claude/rules/bank0_budget.md`.
+- Update `KNOWN_LIMITATIONS.md` (severity drops on the bank-`$00` and RAM-`$2000`
+  entries); close **B1/B3/B4 in the catalogue as "subsumed by A6"**, mark B2 done.
+
+## 4. Test strategy (luna, not the removed bridge)
+
+The catalogue's acceptance criteria predate the luna migration and reference
+`tools/opensnes-emu/test/fixtures/runtime/` + "the snes9x bridge". **Re-home all of
+that onto luna**: runtime-correctness = a ROM that computes results into WRAM +
+`luna state --assert BANK:OFF=HEX` (exactly the `probes/` pattern). This becomes the
+permanent regression gate so 32-bit codegen can't silently rot — the single most
+important deliverable of Phase 0.
+
+## 5. Risk & rollback
+
+- **Highest-risk area:** the QBE slot allocator + emit pass — the same code that
+  carried the C.5 padding bug and the `__mul32` bank-byte bug. Every QBE patch must
+  be re-validated against 4-byte slots.
+- **Rollback:** each phase is its own `wip/` branch; develop only advances on a
+  green gate. The `Kl`/pointer changes are compiler-internal — a bad phase is
+  reverted by not merging, not by touching shipped ROMs.
+- **Cross-arch:** keep the visual gate on `--print-fbhash` (cross-arch stable); the
+  new runtime fixtures assert WRAM values (deterministic), not raw WRAM hashes (see
+  the H7 cross-arch caveat — `wram_regress` is local-only).
+
+## 6. Definition of done
+
+- A7: all `Kl` ops correct, runtime fixtures green, ABI/PINS updated.
+- A6: `sizeof(void*)==4`, indirect calls cross banks, C.5 reverted, framework +
+  chip examples green.
+- B2: C variables work above `$2000` (luna round-trip fixture).
+- B1: a tight example ships a large asset outside bank `$00` with no `*Bank` call;
+  ratchet tightened; KNOWN_LIMITATIONS severities dropped; B1/B3/B4 closed as
+  subsumed.
+- One CHANGELOG section (likely a minor bump, e.g. v0.22.0) covering the unblock:
+  "assets and C RAM are no longer confined to bank `$00` / below `$2000`."
+
+## 7. Open questions for the maintainer
+
+1. **One chantier or staged releases?** A7 alone (Phase 1) is shippable as a patch
+   (finishes 32-bit math). A6+B1+B2 is the bigger minor. Ship A7 first, or hold all
+   for one v0.22.0?
+2. **Pointer size 4 vs 3 bytes** — the catalogue picks 4 (alignment sanity, dead
+   high byte). Confirm before Phase 2 (it's expensive to change later).
+3. **B2 emit:** per-symbol bank detection vs always-explicit-bank for RAM (simpler,
+   ~1 cycle/access). Recommend always-explicit unless a hot-path benchmark objects.
+
+---
+
+**Cross-references:** `.claude/STRUCTURAL_DEFECTS.md` (A7/A6/B1/B2 detail),
+`compiler/ABI.md` (type sizes / calling convention), `compiler/PINS.md` (QBE
+patches), `.claude/rules/bank0_budget.md` (the ratchet), `KNOWN_LIMITATIONS.md`
+(the two user-facing constraints this chantier lifts).

--- a/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
+++ b/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
@@ -106,6 +106,49 @@ rules).
 - Update `KNOWN_LIMITATIONS.md` (severity drops on the bank-`$00` and RAM-`$2000`
   entries); close **B1/B3/B4 in the catalogue as "subsumed by A6"**, mark B2 done.
 
+## 3b. Phase 0 OUTCOME (2026-06-22) — A7 is far more done than the catalogue says
+
+**Audit.** The QBE w65816 backend already implements the `Kl` class broadly —
+`Oload`/`Ostore`/`Ostorel`, `Oadd`/`Osub` (carry chains), `Omul` (`__mul32`),
+`Odiv`/`Oudiv`/`Orem`/`Ourem` (`tcc_sdivmod32`/`tcc_udivmod32`), `Oshl`/`Oshr`/
+`Osar` (pair sequences), `Oneg`/`Oand`/`Oor`/`Oxor`, comparisons, plus high-half
+dead/zero optimization pre-passes. The catalogue's premise ("never extended past
+16-bit", "NOT yet attempted") is **stale** — prior chantiers (incl. fix32 v0.21.0)
+did the bulk. **A7's remaining work is verification + edge-case fixes, not a
+from-scratch implementation.**
+
+**Runtime harness built** — `devtools/compiler-tests/runtime/a7_32bit/`
+(`main.c` + `Makefile` + `test_a7_32bit.py`): a ROM computing 13 s32/u32 ops into
+WRAM globals, checked via `luna state --assert`. Run:
+`cd devtools/compiler-tests/runtime/a7_32bit && make && python3 test_a7_32bit.py`.
+**Result: 12/13 correct, 1 real bug (xfail'd).** This is the permanent A7 gate —
+the static C→ASM checks pass even on the broken case, so only this catches it.
+
+**The one real bug (= A7 Phase 1 scope):**
+`(s32)-256 >> 4` folds to `0x0FFFFFF0` instead of `0xFFFFFFF0`. Root cause is
+**not the codegen** (the `Osar Kl` emit path looks correct) but the **constant
+folder**: `compiler/qbe/fold.c:80`
+`case Osar: x = (w ? l.s : (int32_t)l.s) >> (r.u & (31|w<<5));`
+On w65816 `Kl` is **32-bit**, but QBE folds it as 64-bit (`w==1` → `l.s`,
+64-bit). A negative 32-bit constant is stored in the 64-bit `con` **without
+sign-extension** (`0x00000000FFFFFF00`), so the 64-bit arithmetic `>>` fills from
+bit 63 (=0). `Oshr` (logical) survives because logical-shifting a zero-extended
+value gives the right low-32; only sign-dependent folds break.
+
+**Latent siblings (verify in Phase 1):** the same non-sign-extended-con issue
+affects **signed `Kl` divide/mod and signed comparisons** on negative 32-bit
+constants — add cases to the harness before fixing.
+
+**Phase 1 fix options (decide before coding — Class A, fold pass is delicate):**
+- **(A) sign-extend 32-bit constants into the 64-bit `con` at materialization** —
+  fixes Osar + signed div/cmp at the source, keeps `fold.c` generic. More
+  invasive (find the Kl-constant build path); broadest correctness.
+- **(B) make `fold.c` treat `Kl` as 32-bit on this fork** (`(int32_t)l.s` for
+  Osar, mask others to 32-bit) — localized, matches the backend's Kl=32-bit
+  reality, but touches generic QBE core and must be swept across every Kl fold.
+- Either way: extend the harness (signed div/cmp), then fix, then gate green,
+  then revisit B5's "blocked by A7" note (already shipped) and ship A7 as a patch.
+
 ## 4. Test strategy (luna, not the removed bridge)
 
 The catalogue's acceptance criteria predate the luna migration and reference

--- a/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
+++ b/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
@@ -149,6 +149,29 @@ constants — add cases to the harness before fixing.
 - Either way: extend the harness (signed div/cmp), then fix, then gate green,
   then revisit B5's "blocked by A7" note (already shipped) and ship A7 as a patch.
 
+## 3c. Phase 1 DONE (2026-06-22) — A7 fixed
+
+**Blast radius (measured by extending the harness with signed div/mod/compare on
+negative 32-bit constants):** narrower than feared. The asm proved signed
+`Kl` div/mod take the **runtime** path (`tcc_sdivmod32`, not folded) and signed
+compares are branch-coded — both correct. **Only the `Osar` constant-fold was
+broken** (two cases: `>>4` and `>>8`).
+
+**Fix:** `compiler/qbe/fold.c` `case Osar` now uses 32-bit signed semantics
+(`(int32_t)l.s >> (r.u & 31)`) — correct for w65816 where `Kl` is 32-bit and there
+is no 64-bit integer. One-line change, commented for a future QBE rebase. qbe
+fork commit `1884a20` on `fix/a6-a7-leaf-opt-kl-frameless`; `compiler/PINS.md`
+bumped `e50f148 → 1884a20` (50 patches); `make verify-toolchain` green.
+
+**Validation:** the runtime harness is now **18/18** (no xfail) and is a permanent
+gate — wired into `make tests` and the CI `functional-tests` job. Full Class-A
+re-validation: `make clean && make` (compiler + lib + 56 examples) + `make tests`
+→ compiler checks 10/10, coverage 54 OK / 2 INPUT-DEP, **visual 56/56 (no fbhash
+drift)**, probes 10/10. Ships as a patch (v0.21.2).
+
+**Deferred (unchanged):** A6 / B1 / B2 (Phases 2–4) remain a follow-up chantier;
+decisions #2 (pointer = 4 bytes) and #3 (B2 per-symbol bank) pre-recorded above.
+
 ## 4. Test strategy (luna, not the removed bridge)
 
 The catalogue's acceptance criteria predate the luna migration and reference

--- a/.github/workflows/opensnes_build.yml
+++ b/.github/workflows/opensnes_build.yml
@@ -255,6 +255,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: scripts/install-luna.sh
 
+      - name: A7 32-bit runtime correctness
+        # Builds the s32/u32 fixture ROM and asserts its WRAM results via luna.
+        # Runtime gate the static C→ASM checks can't provide (they pass even on
+        # broken 32-bit codegen — see chantier A7 Phase 0/1).
+        run: |
+          make -s -C devtools/compiler-tests/runtime/a7_32bit
+          python3 devtools/compiler-tests/runtime/a7_32bit/test_a7_32bit.py
+
       - name: Corpus liveness coverage
         run: python3 tools/luna-test/luna_runner.py --coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to OpenSNES are documented in this file.
 OpenSNES is forked from [PVSnesLib](https://github.com/alekmaul/pvsneslib). This changelog
 covers changes made since the fork.
 
+## [0.21.2] — 2026-06-22
+
+Patch release — one compiler correctness fix (32-bit arithmetic) plus the
+test-infrastructure that found it. No API / library / runtime changes.
+
+### Fixed
+- **Compiler (32-bit `Kl`)**: arithmetic shift-right of a *negative* 32-bit
+  constant was constant-folded with the sign dropped — `(s32)-256 >> 4` gave
+  `0x0FFFFFF0` instead of `0xFFFFFFF0`. QBE's fold pass evaluated the `Kl` shift
+  as 64-bit on a zero-extended constant; on w65816 `Kl` is 32-bit, so `Osar` now
+  folds with 32-bit signed semantics (`compiler/qbe/fold.c`). (chantier A7)
+
+### Added
+- 32-bit (`s32`/`u32`) **runtime-correctness fixture**
+  (`devtools/compiler-tests/runtime/a7_32bit/`, 18 cases checked via
+  `luna state --assert`), wired into `make tests` and CI — a permanent codegen
+  gate the static C→ASM checks can't provide (they pass even on broken 32-bit
+  arithmetic).
+
 ## [0.21.1] — 2026-06-22
 
 Test-infrastructure hardening + cleanup release. No SDK API, library, compiler,

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,8 @@ tests: test-compiler
 	@python3 tools/luna-test/luna_runner.py --coverage
 	@python3 tools/luna-test/luna_runner.py --compare
 	@python3 tools/luna-test/probes/run_all.py
+	@$(MAKE) -s -C devtools/compiler-tests/runtime/a7_32bit
+	@python3 devtools/compiler-tests/runtime/a7_32bit/test_a7_32bit.py
 	@echo "ALL CHECKS PASSED (luna)"
 
 # Compile-time cc65816 C→ASM pattern checks (no emulator needed).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ and **what is next**.
 
 ---
 
-## Current Status: post-v0.21.1 (developing toward v0.22.0)
+## Current Status: post-v0.21.2 (developing toward v0.22.0)
 
 A modern, well-tested SNES SDK ready for serious hobby development, game jams,
 and educational use, building toward commercial-grade maturity. The compiler

--- a/compiler/PINS.md
+++ b/compiler/PINS.md
@@ -30,7 +30,7 @@ reformat without updating the script.
 | path | sha | source |
 |------|-----|--------|
 | compiler/cproc | c7552693ae7fe3bee034d48e06a182ecc5da08bd | github.com/k0b3n4irb/cproc:fix/a1-followup-long-kl |
-| compiler/qbe | e50f1481f0f0afb1d6b4c82bfe277fac43a20ccf | github.com/k0b3n4irb/qbe:fix/a6-a7-leaf-opt-kl-frameless |
+| compiler/qbe | 1884a20cf7f3b500b5e6986022a9a4ee43ba21d2 | github.com/k0b3n4irb/qbe:fix/a6-a7-leaf-opt-kl-frameless |
 | compiler/wla-dx | ffe59ca1db32a4e7b40e16674acb844a5a0160ef | github.com/k0b3n4irb/wla-dx:master |
 <!-- END PINS -->
 
@@ -63,11 +63,12 @@ own structural defect is tracked as A6 in the structural-defects catalogue;
 reducing pointer storage cascades through QBE w65816's indirect-call emit
 pass). Empirically validated against the full quick test suite.
 
-### compiler/qbe — 49 patches (the bulk of the SDK's compiler magic)
+### compiler/qbe — 50 patches (the bulk of the SDK's compiler magic)
 
 Selected highlights (full list via `git -C compiler/qbe log HEAD --not upstream/master --oneline`):
 
 ```
+1884a20  fix(qbe): fold Osar as 32-bit signed on w65816 (chantier A7 Phase 1)
 179676e  feat(w65816): chantier A6+A7 — full pointer ABI + Kl pair lowering
 5c23467  fix(qbe): guard crash_handler behind __has_include(<execinfo.h>)
 444edea  fix(qbe): guard inline_record_dat_ref against DStart/DEnd stack garbage

--- a/devtools/compiler-tests/runtime/a7_32bit/Makefile
+++ b/devtools/compiler-tests/runtime/a7_32bit/Makefile
@@ -1,0 +1,11 @@
+OPENSNES := $(shell cd ../../../.. && pwd)
+
+TARGET   := a7_32bit.sfc
+ROM_NAME := A7 32BIT TEST
+
+USE_LIB  := 1
+LIB_MODULES := console sprite dma background
+
+CSRC := main.c
+
+include $(OPENSNES)/make/common.mk

--- a/devtools/compiler-tests/runtime/a7_32bit/main.c
+++ b/devtools/compiler-tests/runtime/a7_32bit/main.c
@@ -1,0 +1,55 @@
+/*
+ * A7 runtime-correctness fixture — 32-bit (s32/u32, QBE Kl class) arithmetic.
+ *
+ * Computes a battery of 32-bit operations into WRAM globals, which the harness
+ * (test_a7_32bit.py, via `luna state --assert`) checks against the expected
+ * values. This is the RUNTIME gate the A7 chantier needs: the static C->ASM
+ * pattern checks pass even on a half-correct Kl implementation, so only an
+ * actual execution check proves the codegen.
+ *
+ * Globals live in bank $00 WRAM (< $2000), so `--assert 00:<off>=<bytes>` reads
+ * them. u32 is little-endian: value V -> bytes V&FF, V>>8, V>>16, V>>24.
+ */
+#include <snes.h>
+
+/* Results — kept as explicit u32/s32/u16 so each Kl op path is exercised. */
+u32 r_add;     /* 0x0000FFFF + 1            -> 0x00010000 (carry low->high) */
+u32 r_sub;     /* 0x00010000 - 1            -> 0x0000FFFF (borrow high->low) */
+u32 r_mul;     /* 0x00001234 * 0x10         -> 0x00012340 */
+u32 r_mulhi;   /* 0x00010000 * 0x10         -> 0x00100000 (result in high half) */
+u32 r_shl;     /* 1u << 20                  -> 0x00100000 */
+u32 r_shr;     /* 0x80000000 >> 4 (logical) -> 0x08000000 */
+u32 r_sar;     /* (s32)-256 >> 4 (arith)    -> 0xFFFFFFF0 */
+u32 r_div;     /* 0x00100000 / 0x10         -> 0x00010000 */
+u32 r_mod;     /* 0x00100003 % 0x10         -> 0x00000003 */
+u32 r_and;     /* 0x0F0F0F0F & 0x00FFFF00   -> 0x000F0F00 */
+u32 r_or;      /* 0x0F0F0F0F | 0x00FFFF00   -> 0x0FFFFF0F */
+u32 r_xor;     /* 0x0F0F0F0F ^ 0x00FFFF00   -> 0x0FF0F00F */
+u16 r_cmp;     /* (0x10000u > 0xFFFFu)      -> 1 (high-half-aware compare) */
+
+int main(void) {
+    u32 a, b;
+    s32 s;
+
+    a = 0x0000FFFFu; r_add = a + 1u;
+    a = 0x00010000u; r_sub = a - 1u;
+    a = 0x00001234u; r_mul = a * 0x10u;
+    a = 0x00010000u; r_mulhi = a * 0x10u;
+    a = 1u; r_shl = a << 20;   /* a is u32 — shift the 32-bit operand, not a 16-bit `1u` */
+    a = 0x80000000u; r_shr = a >> 4;
+    s = -256;        r_sar = (u32)(s >> 4);
+    a = 0x00100000u; r_div = a / 0x10u;
+    a = 0x00100003u; r_mod = a % 0x10u;
+    a = 0x0F0F0F0Fu; b = 0x00FFFF00u;
+    r_and = a & b;
+    r_or  = a | b;
+    r_xor = a ^ b;
+    r_cmp = (0x00010000u > 0x0000FFFFu) ? 1u : 0u;
+
+    consoleInit();
+    setScreenOn();
+    while (1) {
+        WaitForVBlank();
+    }
+    return 0;
+}

--- a/devtools/compiler-tests/runtime/a7_32bit/main.c
+++ b/devtools/compiler-tests/runtime/a7_32bit/main.c
@@ -26,6 +26,12 @@ u32 r_and;     /* 0x0F0F0F0F & 0x00FFFF00   -> 0x000F0F00 */
 u32 r_or;      /* 0x0F0F0F0F | 0x00FFFF00   -> 0x0FFFFF0F */
 u32 r_xor;     /* 0x0F0F0F0F ^ 0x00FFFF00   -> 0x0FF0F00F */
 u16 r_cmp;     /* (0x10000u > 0xFFFFu)      -> 1 (high-half-aware compare) */
+/* Latent siblings of the Osar fold bug: signed Kl ops on negative 32-bit consts. */
+u32 r_sdiv;    /* (s32)-256 / 16  (signed)  -> 0xFFFFFFF0 (-16) */
+u32 r_smod;    /* (s32)-257 % 16  (signed)  -> 0xFFFFFFFF (-1) */
+u16 r_slt;     /* ((s32)-1 < 0)             -> 1 (signed compare) */
+u16 r_sgt;     /* ((s32)-5 > (s32)3)        -> 0 (signed compare) */
+u32 r_sar8;    /* (s32)-1 >> 8    (arith)   -> 0xFFFFFFFF */
 
 int main(void) {
     u32 a, b;
@@ -45,6 +51,11 @@ int main(void) {
     r_or  = a | b;
     r_xor = a ^ b;
     r_cmp = (0x00010000u > 0x0000FFFFu) ? 1u : 0u;
+    s = -256; r_sdiv = (u32)(s / 16);
+    s = -257; r_smod = (u32)(s % 16);
+    s = -1;   r_slt  = (s < 0) ? 1u : 0u;
+    s = -5;   r_sgt  = (s > 3) ? 1u : 0u;
+    s = -1;   r_sar8 = (u32)(s >> 8);
 
     consoleInit();
     setScreenOn();

--- a/devtools/compiler-tests/runtime/a7_32bit/test_a7_32bit.py
+++ b/devtools/compiler-tests/runtime/a7_32bit/test_a7_32bit.py
@@ -34,6 +34,11 @@ CASES = [
     ("r_or",    4, 0x0FFFFF0F),
     ("r_xor",   4, 0x0FF0F00F),
     ("r_cmp",   2, 0x0001),
+    ("r_sdiv",  4, 0xFFFFFFF0),
+    ("r_smod",  4, 0xFFFFFFFF),
+    ("r_slt",   2, 0x0001),
+    ("r_sgt",   2, 0x0000),
+    ("r_sar8",  4, 0xFFFFFFFF),
 ]
 
 
@@ -43,12 +48,13 @@ def le_bytes(value: int, width: int) -> str:
 
 # Known-failing cases (xfail) — documented A7 bugs not yet fixed. Remove an entry
 # when its fix lands; an unexpected PASS (XPASS) then flags the stale xfail.
-#   r_sar: QBE constant-fold of `Osar` on a Kl (32-bit-on-w65816) value uses
-#          64-bit arithmetic on a NON-sign-extended con, so arithmetic-shift-right
-#          of a negative 32-bit constant fills from bit 63 (=0) instead of bit 31.
-#          Root cause: compiler/qbe/fold.c:80. Same class is latent for signed
-#          Kl divide/compare on negative constants. Fix = chantier A7 Phase 1.
-KNOWN_FAIL = {"r_sar"}
+#
+# (empty) — the Osar fold bug found in Phase 0 is FIXED: `compiler/qbe/fold.c`
+# now folds `Osar` with 32-bit signed semantics (w65816 Kl is 32-bit), so
+# arithmetic-shift-right of a negative 32-bit constant sign-extends correctly
+# (r_sar, r_sar8). Signed Kl div/mod/compare were verified to go through the
+# runtime path (not folded), so they were never affected.
+KNOWN_FAIL: set[str] = set()
 
 
 def run() -> int:

--- a/devtools/compiler-tests/runtime/a7_32bit/test_a7_32bit.py
+++ b/devtools/compiler-tests/runtime/a7_32bit/test_a7_32bit.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Runtime-correctness check for A7 (32-bit Kl codegen).
+
+Builds nothing — assumes `make` produced a7_32bit.sfc. Resolves each result
+global from the .sym and asserts its WRAM value via `luna state --assert`. This
+is the gate the A7 chantier needs (static C->ASM checks can't prove runtime
+correctness of 32-bit arithmetic).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[3]
+sys.path.insert(0, str(REPO / "tools" / "luna-test" / "probes"))
+from lib import find_luna, sym_of, assert_mem  # noqa: E402
+
+ROM = HERE / "a7_32bit.sfc"
+STEPS = 1_000_000
+
+# (global, width-bytes, expected-value)
+CASES = [
+    ("r_add",   4, 0x00010000),
+    ("r_sub",   4, 0x0000FFFF),
+    ("r_mul",   4, 0x00012340),
+    ("r_mulhi", 4, 0x00100000),
+    ("r_shl",   4, 0x00100000),
+    ("r_shr",   4, 0x08000000),
+    ("r_sar",   4, 0xFFFFFFF0),
+    ("r_div",   4, 0x00010000),
+    ("r_mod",   4, 0x00000003),
+    ("r_and",   4, 0x000F0F00),
+    ("r_or",    4, 0x0FFFFF0F),
+    ("r_xor",   4, 0x0FF0F00F),
+    ("r_cmp",   2, 0x0001),
+]
+
+
+def le_bytes(value: int, width: int) -> str:
+    return "".join(f"{(value >> (8 * i)) & 0xFF:02X}" for i in range(width))
+
+
+# Known-failing cases (xfail) — documented A7 bugs not yet fixed. Remove an entry
+# when its fix lands; an unexpected PASS (XPASS) then flags the stale xfail.
+#   r_sar: QBE constant-fold of `Osar` on a Kl (32-bit-on-w65816) value uses
+#          64-bit arithmetic on a NON-sign-extended con, so arithmetic-shift-right
+#          of a negative 32-bit constant fills from bit 63 (=0) instead of bit 31.
+#          Root cause: compiler/qbe/fold.c:80. Same class is latent for signed
+#          Kl divide/compare on negative constants. Fix = chantier A7 Phase 1.
+KNOWN_FAIL = {"r_sar"}
+
+
+def run() -> int:
+    if not ROM.is_file():
+        sys.exit(f"ROM missing: {ROM} (run `make` first)")
+    luna = find_luna()
+    real_fails = 0
+    for name, width, want in CASES:
+        bank, off = sym_of(ROM, name)
+        ok, detail = assert_mem(luna, ROM, STEPS, [(bank, off, le_bytes(want, width))])
+        if name in KNOWN_FAIL:
+            if ok:
+                print(f"  XPASS {name} == 0x{want:0{width*2}X}  ← fixed! remove from KNOWN_FAIL")
+                real_fails += 1
+            else:
+                print(f"  XFAIL {name} == 0x{want:0{width*2}X}  (known A7 bug, see header)")
+        elif ok:
+            print(f"  PASS  {name} == 0x{want:0{width*2}X}")
+        else:
+            print(f"  FAIL  {name} == 0x{want:0{width*2}X}  [{detail}]")
+            real_fails += 1
+    passed = sum(1 for n, _, _ in CASES if n not in KNOWN_FAIL)
+    print(f"\nA7 32-bit runtime: {passed - real_fails}/{passed} ok"
+          f" (+{len(KNOWN_FAIL)} xfail: {', '.join(sorted(KNOWN_FAIL))})")
+    return 1 if real_fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/lib/include/snes.h
+++ b/lib/include/snes.h
@@ -56,10 +56,10 @@
 #define OPENSNES_VERSION_MINOR 21
 
 /** @brief OpenSNES patch version */
-#define OPENSNES_VERSION_PATCH 1
+#define OPENSNES_VERSION_PATCH 2
 
 /** @brief OpenSNES version string */
-#define OPENSNES_VERSION_STRING "0.21.1"
+#define OPENSNES_VERSION_STRING "0.21.2"
 
 /*============================================================================
  * Core Headers


### PR DESCRIPTION
Release **v0.21.2** — patch. Tag cut from `main` after merge (release.yml enforces
tag-on-main).

**One compiler correctness fix + the test-infra that found it. No API changes.**
- fix: `(s32)x >> n` on a negative 32-bit constant folded with the sign dropped
  (`0x0FFFFFF0` vs `0xFFFFFFF0`) — QBE folded `Kl` as 64-bit; now 32-bit signed
  (chantier A7).
- new: `devtools/compiler-tests/runtime/a7_32bit/` runtime-correctness fixture
  (luna `--assert`), a permanent codegen gate; A7 marked resolved.

After merge:
```
git checkout main && git pull
git tag -a v0.21.2 -m "v0.21.2 — Osar 32-bit fold fix + A7 runtime gate"
git push origin v0.21.2
```