### PR TITLE
test(compiler): A6 Phase 1 — far-pointer runtime gate proves the deref bug

### DIFF
--- a/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
+++ b/.claude/notes/chantiers/32bit_pointers_a7_a6_b1_b2.md
@@ -214,6 +214,38 @@ codegen.
 **Net:** A6 is ~half done (pointer size + calls); the hard, high-value half (data
 deref → lifts B1/B2) remains and is now precisely scoped.
 
+### Phase 1 — runtime gate built + bug proven (2026-06-22)
+`devtools/compiler-tests/runtime/a6_farptr/` puts a sentinel in **BANK 2**
+(`a6_sentinel.asm`, lands at `02:8000`), takes a **volatile** far pointer to it
+(forces a register-indirect deref the compiler can't fold to a direct access),
+and luna-`--assert`s the results. Outcome, isolating storage vs deref:
+- **`r_ptrhi == 0x0002` PASS** — the pointer *value* keeps its bank byte (storage
+  is correct).
+- **`r_d0/d3/d7` FAIL** (xfail) — the deref reads bank `$00` garbage (0x08/0xe2/
+  0x8d at `$00:8000+`) instead of 0x11/0x44/0x88. The gap is the **deref only**.
+
+So the bug is proven and isolated. The harness is committed with the 3 deref
+cases xfail'd (not yet wired into `make tests`/CI — flips green when fixed).
+
+### Phase 1 — the codegen design decision (maintainer call needed)
+Each deref site (`emit.c` ~3482/3519/3552/3617 + load counterparts) is
+`tax … lda.l/sta.l $0000,x` — X = the pointer's low 16, bank fixed `$00`. The
+65816 has no "store to (X + runtime bank)"; the fix is **direct-page indirect
+long** (`lda [dp],y` / `sta [dp],y`) after writing the 3-byte pointer to a DP
+scratch. That costs ~+2–5 cyc **plus** ~3 stores to set up the DP pointer, **per
+deref**. Two ways:
+- **(F) always-far** — every pointer deref uses `[dp],y`. Simple, but a real perf
+  regression on the ~99% bank-`$00` case (every array index / C-RAM access).
+- **(S) bank-0 fast path** — keep `lda.l $0000,x` when the pointer is *provably*
+  bank `$00` (C RAM, `&local`, bank-0 globals), use `[dp],y` only for
+  possibly-far pointers. Preserves perf; needs a "provably bank-0" dataflow
+  analysis (related to the existing `mark_addr_only_kl`/`temp_addr_only` machinery,
+  which already tracks "bank byte dead"). More complex, higher risk.
+
+**Recommendation: (S)** — a game SDK can't eat a per-access cycle tax on every
+array index. (S) is multi-day and must be done carefully (a wrong bank-0 proof =
+silent corruption). This is the decision to confirm before the codegen work.
+
 ## 4. Test strategy (luna, not the removed bridge)
 
 The catalogue's acceptance criteria predate the luna migration and reference

--- a/devtools/compiler-tests/runtime/a6_farptr/Makefile
+++ b/devtools/compiler-tests/runtime/a6_farptr/Makefile
@@ -1,0 +1,12 @@
+OPENSNES := $(shell cd ../../../.. && pwd)
+
+TARGET   := a6_farptr.sfc
+ROM_NAME := A6 FARPTR TEST
+
+USE_LIB  := 1
+LIB_MODULES := console sprite dma background
+
+CSRC   := main.c
+ASMSRC := a6_sentinel.asm
+
+include $(OPENSNES)/make/common.mk

--- a/devtools/compiler-tests/runtime/a6_farptr/a6_sentinel.asm
+++ b/devtools/compiler-tests/runtime/a6_farptr/a6_sentinel.asm
@@ -1,0 +1,8 @@
+; A6 far-pointer fixture data — placed in BANK 2 so its address has a non-zero
+; bank byte. The C side derefs a pointer to it; with the bank-$00-hardcoded
+; deref codegen (`lda.l $0000,x`) this reads bank $00 garbage instead.
+.BANK 2 SLOT 0
+.SECTION "a6_sentinel" SEMIFREE
+a6_sentinel:
+    .db $11, $22, $33, $44, $55, $66, $77, $88
+.ENDS

--- a/devtools/compiler-tests/runtime/a6_farptr/main.c
+++ b/devtools/compiler-tests/runtime/a6_farptr/main.c
@@ -1,0 +1,35 @@
+/*
+ * A6 far-pointer runtime fixture — deref of a pointer to data OUTSIDE bank $00.
+ *
+ * a6_sentinel lives in BANK 2 (see a6_sentinel.asm). A *volatile* pointer forces
+ * a register-indirect deref (the compiler can't fold it to a direct symbol
+ * access), exercising the `lda.l $0000,x` path that ignores the bank byte.
+ *
+ * Expected once A6 lowers derefs as 24-bit: r_d0/3/7 = 0x11/0x44/0x88.
+ * r_ptrhi isolates storage vs deref: it must be 0x0002 (the pointer VALUE keeps
+ * the bank byte) even if the deref is still buggy.
+ */
+#include <snes.h>
+
+extern const u8 a6_sentinel[];
+volatile const u8 *g_p;   /* volatile → opaque far pointer, register-indirect deref */
+
+u8  r_d0;     /* g_p[0] -> 0x11 */
+u8  r_d3;     /* g_p[3] -> 0x44 */
+u8  r_d7;     /* g_p[7] -> 0x88 */
+u16 r_ptrhi;  /* high 16 of the pointer value -> 0x0002 (bank byte present) */
+
+int main(void) {
+    g_p = a6_sentinel;
+    r_d0 = g_p[0];
+    r_d3 = g_p[3];
+    r_d7 = g_p[7];
+    r_ptrhi = (u16)(((u32)g_p) >> 16);
+
+    consoleInit();
+    setScreenOn();
+    while (1) {
+        WaitForVBlank();
+    }
+    return 0;
+}

--- a/devtools/compiler-tests/runtime/a6_farptr/test_a6_farptr.py
+++ b/devtools/compiler-tests/runtime/a6_farptr/test_a6_farptr.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""A6 far-pointer runtime check: deref of a pointer to BANK 2 data.
+
+Proves the A6 remaining gap: the pointer VALUE keeps its bank byte (r_ptrhi),
+but dereferencing it reads bank $00 (the `lda.l $0000,x` codegen). The deref
+cases are xfail until A6 Phase 1 lowers pointer derefs as 24-bit.
+"""
+import sys
+from pathlib import Path
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parents[3] / "tools" / "luna-test" / "probes"))
+from lib import find_luna, sym_of, assert_mem  # noqa: E402
+ROM = HERE / "a6_farptr.sfc"; STEPS = 1_000_000
+CASES = [("r_ptrhi", 2, 0x0002), ("r_d0", 1, 0x11), ("r_d3", 1, 0x44), ("r_d7", 1, 0x88)]
+# Deref through a far pointer is bank-$00-hardcoded (emit.c `lda.l $0000,x`);
+# fixed in A6 Phase 1. r_ptrhi (the pointer value's bank byte) already works.
+KNOWN_FAIL = {"r_d0", "r_d3", "r_d7"}
+def le(v, w): return "".join(f"{(v>>(8*i))&0xFF:02X}" for i in range(w))
+def run():
+    if not ROM.is_file(): sys.exit(f"ROM missing: {ROM} (run make)")
+    luna = find_luna(); real = 0
+    for name, w, want in CASES:
+        b, o = sym_of(ROM, name)
+        ok, det = assert_mem(luna, ROM, STEPS, [(b, o, le(want, w))])
+        if name in KNOWN_FAIL:
+            print(f"  {'XPASS' if ok else 'XFAIL'} {name} == 0x{want:0{w*2}X}"
+                  + ("  ← fixed! remove from KNOWN_FAIL" if ok else "  (A6 deref gap)"))
+            real += 1 if ok else 0
+        else:
+            print(f"  {'PASS' if ok else 'FAIL'}  {name} == 0x{want:0{w*2}X}" + ("" if ok else f"  [{det}]"))
+            real += 0 if ok else 1
+    passed = sum(1 for n,_,_ in CASES if n not in KNOWN_FAIL)
+    print(f"\nA6 far-ptr: {passed-real}/{passed} ok (+{len(KNOWN_FAIL)} xfail: deref gap)")
+    return 1 if real else 0
+sys.exit(run())


### PR DESCRIPTION
Phase 1 step 1 (by dichotomy): build the gate + prove/isolate the bug. **No
codegen change yet** — pending a design decision.

`devtools/compiler-tests/runtime/a6_farptr/` puts a sentinel in **BANK 2**
(`02:8000`), takes a **volatile** far pointer, derefs it, luna-asserts:
- `r_ptrhi == 0x0002` **PASS** — pointer value keeps its bank byte (storage OK).
- `r_d0/d3/d7` **xfail** — deref reads bank `$00` garbage. Gap = **deref only**.

Committed with the 3 deref cases xfail'd (not yet in make tests/CI — flips green
when the codegen lands).

**Next (maintainer call, plan §3d):** deref fix = direct-page indirect long
(`[dp],y`), costs per-access. Decide **always-far** (simple, perf tax on every
pointer access) vs **bank-0 fast-path analysis** (preserves perf, more complex).
Recommend the latter.