### PR TITLE
fix(docs,devtools): TIER 1 — kill onboarding doc drift + harden sentinel

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,6 +88,15 @@ jobs:
         # .claude/rules/doc_consistency.md.
         run: python3 devtools/check_doc_drift.py
 
+      - name: Run test_check_doc_drift.py
+        # Regression suite for the TIER-1 sentinel extensions: the phantom-API
+        # detector (a function called in an onboarding-doc C snippet must exist in
+        # the headers — caught consoleDrawText) and the extended example-count
+        # patterns (must match the real phrasings, must NOT match prose like
+        # "12 examples were flagged").
+        working-directory: devtools
+        run: python3 -m unittest test_check_doc_drift
+
   nmi-race-tests:
     name: NMI/WRAM race lint regression tests (test_check_nmi_wram_race.py)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ include $(OPENSNES)/make/common.mk
 ## Code Style
 
 - C: 4 spaces, K&R braces, snake_case functions/vars, UPPER_CASE constants
-- Use fixed-width types: `u8`, `u16`, `s16`, `u32` (from `snes.h`). `unsigned int` = 4 bytes, `unsigned long` = 8 bytes on this target.
+- Use fixed-width types: `u8`, `u16`, `s16`, `u32` (from `snes.h`). `unsigned int` = 2 bytes, `unsigned long` = 4 bytes on this target (since chantier A1; `compiler/cproc/type.c` `typeint` size 2 / `typelong` size 4). This matches `.claude/rules/compiler.md`.
 - ASM: labels at column 0, instructions indented with tab, `.section` for organization
 - Commits: [Conventional Commits](https://www.conventionalcommits.org/) — `feat(scope):`, `fix(scope):`, `perf(scope):`, etc.
 - Scopes: `lib`, `compiler`, `runtime`, `tools`, `examples`, `build`

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ values) — required reading before porting any function from PVSnesLib.
 | **C11 compiler for the 65816** | cproc + QBE with a custom backend ([benchmark](docs/BENCHMARK.md)) |
 | **30 hardware modules** | PPU, sprites, backgrounds, DMA, HDMA, input, audio, Mode 7, collision, SRAM... |
 | **Asset pipeline** | PNG to tiles, fonts, Impulse Tracker to SPC700 |
-| **54 examples** | From "Hello World" to Tetris with music — each with README and screenshot |
+| **56 examples** | From "Hello World" to Tetris with music — each with README and screenshot |
 | **Framework opt-ins** | Game loop, scene stack, asset bundles — drop them in if they fit, ignore them otherwise |
 | **Debug emulator** | luna (cycle-accurate native emulator) — corpus liveness + visual regression + functional probes; SA-1 / Super FX / DSP-1 run natively |
 | **Cross-platform** | Linux, macOS, Windows — CI-enforced on all three |

--- a/devtools/check_doc_drift.py
+++ b/devtools/check_doc_drift.py
@@ -168,9 +168,15 @@ def check_roadmap_status(canonical: str) -> list[str]:
 # past state intentionally.
 COUNT_PATTERNS = [
     re.compile(r"\b(\d{2,3})\s+working\s+examples?\b", re.IGNORECASE),
-    re.compile(r"\b(\d{2,3})\s+examples?\s+(?:cover|organized|across)", re.IGNORECASE),
+    re.compile(r"\b(\d{2,3})\s+examples?\s+(?:cover|organized|across|from|by topic|as a)",
+               re.IGNORECASE),
+    re.compile(r"\bthrough\s+(\d{2,3})\s+examples?\b", re.IGNORECASE),  # "path through N examples"
+    re.compile(r"\b(\d{2,3})\s+example\s+ROMs?\b", re.IGNORECASE),
+    re.compile(r"\*\*(\d{2,3})\s+examples?\*\*", re.IGNORECASE),  # README bold table cell
     re.compile(r"\bAll\s+(\d{2,3})\s+examples?\b", re.IGNORECASE),
     re.compile(r"\ball\s+(\d{2,3})\s+examples\s+compile\s+cleanly\b", re.IGNORECASE),
+    # Targeted phrasings only (NOT a bare "\d examples") so prose like
+    # "12 examples were flagged" in bank0_budget.md stays a non-match.
 ]
 
 # Files where an example count is allowed to be stale (historical record).
@@ -182,6 +188,14 @@ def _gather_active_doc_paths() -> list[Path]:
     rules = repo_path(".claude/rules")
     if rules.is_dir():
         paths.extend(sorted(rules.glob("*.md")))
+    # Onboarding docs that quote the corpus count (added 2026-06-23, TIER 1):
+    # these are where a newcomer first reads "N examples". docs/ at large is NOT
+    # scanned — some tutorials intentionally pin a past state.
+    for rel in ("examples/README.md", "docs/EXAMPLES_BY_CATEGORY.md",
+                "docs/LEARNING_PATH.md", "docs/mainpage.md"):
+        p = repo_path(rel)
+        if p.is_file():
+            paths.append(p)
     return paths
 
 
@@ -215,6 +229,82 @@ def check_examples_count(canonical: int) -> list[str]:
                     f"`find examples -name main.c | wc -l = {canonical}` — "
                     f"update the line or, if it's an off-by-one drift, "
                     f"replace the number with `<run --list>`-style language"
+                )
+    return drifts
+
+
+# --------------------------------------------------------------------------
+# Check 5: phantom API in onboarding docs (added 2026-06-23, TIER 1)
+# A function CALLED in a ```c block of an onboarding doc must exist in the
+# public headers — else the newcomer's first program fails to link. Caught
+# historically as `consoleDrawText()` in GETTING_STARTED.md ("your first
+# program") and `audioPlaySample(channel, data, size, pitch)` in TROUBLESHOOTING.
+# --------------------------------------------------------------------------
+
+PHANTOM_DOC_PATHS = ["docs/GETTING_STARTED.md", "docs/TROUBLESHOOTING.md"]
+
+# Control-flow + common C stdlib identifiers that appear as `name(` but are not
+# SDK API (so they are not "phantom").
+_PHANTOM_ALLOW = {
+    "if", "for", "while", "switch", "return", "sizeof", "do", "else", "main",
+    "defined", "memcpy", "memset", "memmove", "malloc", "calloc", "realloc",
+    "free", "printf", "sprintf", "snprintf", "strlen", "strcpy", "strncpy",
+    "strcmp", "abs",
+}
+
+
+def _public_api_names() -> set[str]:
+    """Identifiers declared as functions / function-like macros in the headers."""
+    names: set[str] = set()
+    inc = repo_path("lib/include")
+    for hdr in list(inc.glob("snes.h")) + sorted(inc.glob("snes/*.h")):
+        text = hdr.read_text(encoding="utf-8", errors="replace")
+        for m in re.finditer(r"\b([A-Za-z_]\w*)\s*\(", text):
+            names.add(m.group(1))
+    return names
+
+
+def _strip_c_comments(code: str) -> str:
+    code = re.sub(r"/\*.*?\*/", " ", code, flags=re.DOTALL)
+    code = re.sub(r"//[^\n]*", " ", code)
+    return code
+
+
+def phantom_names_in_code(code: str, api: set[str]) -> list[str]:
+    """Pure core (unit-testable): SDK-shaped calls in `code` not in `api`.
+
+    Strips comments, ignores locally-defined functions, control flow, and common
+    stdlib; only considers lowerCamel (oamSet) / CapWord (WaitForVBlank) names so
+    UPPER_CASE macros (KEY_*, OBJSEL) and casts are never flagged.
+    """
+    code = _strip_c_comments(code)
+    defined = set(re.findall(r"\b(?:void|u8|u16|s16|u32|int|static)\s+(\w+)\s*\(", code))
+    bad: list[str] = []
+    for m in re.finditer(r"\b([a-zA-Z_]\w*)\s*\(", code):
+        name = m.group(1)
+        if not re.match(r"^[a-z][A-Za-z0-9]*$|^[A-Z][a-z]\w*$", name):
+            continue
+        if name in api or name in _PHANTOM_ALLOW or name in defined:
+            continue
+        bad.append(name)
+    return bad
+
+
+def check_phantom_api() -> list[str]:
+    api = _public_api_names()
+    drifts: list[str] = []
+    for rel in PHANTOM_DOC_PATHS:
+        path = repo_path(rel)
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for block in re.findall(r"```c\b(.*?)```", text, re.DOTALL):
+            for name in phantom_names_in_code(block, api):
+                idx = text.find(name + "(")
+                lineno = text[:idx].count("\n") + 1 if idx >= 0 else 0
+                drifts.append(
+                    f"{rel}:{lineno}: `{name}(...)` called in a C snippet but not "
+                    f"declared in lib/include/snes/*.h — phantom API (won't link)."
                 )
     return drifts
 
@@ -391,6 +481,7 @@ def run_checks(quiet: bool) -> int:
     all_drifts.extend(check_snes_h_version(canonical_ver))
     all_drifts.extend(check_roadmap_status(canonical_ver))
     all_drifts.extend(check_examples_count(canonical_n))
+    all_drifts.extend(check_phantom_api())
     all_drifts.extend(check_abi_signatures())
 
     if all_drifts:

--- a/devtools/test_check_doc_drift.py
+++ b/devtools/test_check_doc_drift.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Regression tests for check_doc_drift.py's TIER-1 extensions (stdlib unittest):
+the phantom-API detector and the extended example-count patterns."""
+import unittest
+
+from check_doc_drift import COUNT_PATTERNS, phantom_names_in_code
+
+API = {"textPrintAt", "textModeInit", "setScreenOn", "WaitForVBlank",
+       "oamSet", "audioPlaySample"}
+
+
+def _count_matches(line: str):
+    for rx in COUNT_PATTERNS:
+        m = rx.search(line)
+        if m:
+            return int(m.group(1))
+    return None
+
+
+class TestPhantomApi(unittest.TestCase):
+    def test_flags_phantom_call(self):
+        self.assertEqual(phantom_names_in_code('consoleDrawText(8, 10, "x");', API),
+                         ["consoleDrawText"])
+
+    def test_real_api_ok(self):
+        self.assertEqual(phantom_names_in_code('textPrintAt(8, 10, "x"); setScreenOn();', API), [])
+
+    def test_commented_call_ignored(self):
+        self.assertEqual(phantom_names_in_code('// oldThing(0);\n/* gone(1); */', API), [])
+
+    def test_locally_defined_ignored(self):
+        self.assertEqual(phantom_names_in_code('void helper(void){} helper();', API), [])
+
+    def test_upper_macro_and_stdlib_ignored(self):
+        self.assertEqual(phantom_names_in_code('REG_FOO(1); memcpy(a, b, 4); if (x) {}', API), [])
+
+
+class TestCountPatterns(unittest.TestCase):
+    def test_matches_real_phrasings(self):
+        for line in ["56 examples organized by topic", "All 56 examples organized",
+                     "**56 examples**", "56 example ROMs", "through 56 examples",
+                     "56 examples from \"Hello World\""]:
+            self.assertEqual(_count_matches(line), 56, line)
+
+    def test_does_not_match_prose_count(self):
+        # bank0_budget.md: "12 examples were flagged" must NOT be read as a corpus count.
+        self.assertIsNone(_count_matches("flagged that 12 examples were within"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/EXAMPLES_BY_CATEGORY.md
+++ b/docs/EXAMPLES_BY_CATEGORY.md
@@ -1,6 +1,6 @@
 # Browse Examples by Category {#examples_by_category}
 
-All 54 examples organized by topic. For a progressive learning path, see
+All 56 examples organized by topic. For a progressive learning path, see
 @ref learning_path.
 
 ---
@@ -12,7 +12,7 @@ Display text on screen using background tiles and fonts.
 | Example | Description |
 |---------|-------------|
 | @subpage examples_text_hello_world | Your first ROM: PPU setup, tiles, palette, tilemap |
-| @subpage examples_text_text_test | Text positioning, formatting with consoleDrawText |
+| @subpage examples_text_text_test | Text positioning, formatting with textPrintAt |
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -107,7 +107,7 @@ CSRC     := main.c
 
 # Use OpenSNES library
 USE_LIB  := 1
-LIB_MODULES := console sprite dma background input
+LIB_MODULES := console dma text background
 
 # Include the build system
 include $(OPENSNES)/make/common.mk
@@ -118,8 +118,8 @@ include $(OPENSNES)/make/common.mk
 #include <snes.h>
 
 int main(void) {
-    consoleInit();
-    consoleDrawText(8, 10, "Hello SNES!");
+    textModeInit();                     /* sets up the PPU + text engine in one call */
+    textPrintAt(8, 10, "Hello SNES!");  /* NMI auto-flushes the text to VRAM */
     setScreenOn();
 
     while (1) {
@@ -200,7 +200,7 @@ This takes a few minutes. Expected output:
 Building cc65816 compiler...
 Building WLA-DX assembler...
 Building OpenSNES library...
-Building examples... (52 ROMs)
+Building examples... (56 ROMs)
 OpenSNES SDK build complete!
 ```
 

--- a/docs/LEARNING_PATH.md
+++ b/docs/LEARNING_PATH.md
@@ -1,6 +1,6 @@
 # Learn SNES Development {#learning_path}
 
-A progressive learning path through 54 examples, from your first ROM to complete games.
+A progressive learning path through 56 examples, from your first ROM to complete games.
 Each example builds on concepts from earlier ones.
 
 ## Level 1: First Steps

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -152,8 +152,8 @@ oamInitGfxSet(sprite_gfx, sprite_gfx_end - sprite_gfx,
               sprite_pal, sprite_pal_end - sprite_pal,
               0, 0x0000, OBJ_SIZE8_L16);
 
-// 3. Set sprite properties
-oamSet(0, x, y, 3, 0, 0, 0, 0);
+// 3. Set sprite properties — oamSet(id, x, y, tile, palette, priority, flags)
+oamSet(0, x, y, 0, 0, 3, 0);
 
 // 4. Make sure sprite is visible (not hidden)
 // oamSetVisible(0, OBJ_SHOW);  // If needed
@@ -183,7 +183,8 @@ if (pressed & KEY_B) { }    // B button (bit 15)
 **For basic audio**:
 ```c
 audioInit();
-audioPlaySample(channel, sample_data, sample_size, pitch);
+audioLoadSample(0, sample_brr, sample_brr_end - sample_brr, 0); // id, BRR data, size, loop point
+audioPlaySample(0);                                             // play sample id 0
 ```
 
 **For SNESMOD**:

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -7,7 +7,7 @@ Write game logic in C, produce .sfc ROMs that run on emulators or real hardware.
 
 @subpage getting_started -- Install the SDK and build your first ROM
 
-@subpage learning_path -- 54 examples from "Hello World" to complete games
+@subpage learning_path -- 56 examples from "Hello World" to complete games
 
 @subpage examples_by_category -- Browse examples by topic
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # OpenSNES Examples
 
-Learn SNES development step by step. 54 examples organized by topic, building
+Learn SNES development step by step. 56 examples organized by topic, building
 from basic concepts to complete games.
 
 ## Categories
@@ -23,7 +23,7 @@ from basic concepts to complete games.
 | # | Example | What You Will Learn |
 |---|---------|---------------------|
 | 1 | [text/hello_world](text/hello_world/) | PPU, backgrounds, tiles, palette -- your first ROM |
-| 2 | [text/text_test](text/text_test/) | Text positioning, formatting, consoleDrawText |
+| 2 | [text/text_test](text/text_test/) | Text positioning, formatting, textPrintAt |
 | 3 | [graphics/sprites/simple_sprite](graphics/sprites/simple_sprite/) | OAM, sprite display, CGRAM split |
 | 4 | [input/two_players](input/two_players/) | Joypad reading, multiplayer input |
 

--- a/examples/memory/sa1_hello/main.c
+++ b/examples/memory/sa1_hello/main.c
@@ -19,7 +19,7 @@
  * @par What to Observe
  * - On boot you see "SA1 status: NN" where NN is the byte the SA-1
  *   wrote to its shared status slot. Any non-zero value confirms the
- *   coprocessor ran. The expected value here is `0xA1` (set by the
+ *   coprocessor ran. The expected value here is `0xA5` (set by the
  *   bundled `sa1_boot.asm`).
  * - If status is 0x00, the SA-1 didn't run — check that the emulator
  *   recognises SA-1 from the ROM header (Mesen2 is reliable; some

--- a/lib/include/snes/sprite.h
+++ b/lib/include/snes/sprite.h
@@ -321,11 +321,11 @@ void oamInitGfxSet(u8 *tileSource, u16 tileSize, u8 *tilePalette,
  * @param priority Priority (0-3, 3=highest)
  * @param flags Flip flags (bit 6 = H flip, bit 7 = V flip)
  *
- * @warning **Performance**: oamSet() has framesize=158 per call (158 bytes of
- * stack manipulation due to SSA temporaries). Calling it more than 2-3 times
- * per frame in the main loop causes visible jitter on real hardware.
- * Use oamSetFast() or oamSetXYFast() macros for performance-critical code
- * (see "Fast Macro Sprite API" section below).
+ * @note **Performance**: the old framesize=158 cliff (≈3 calls/frame caused
+ * jitter) was RESOLVED by an ASM rewrite — see KNOWN_LIMITATIONS.md
+ * ("`oamSet()` framesize cliff — RESOLVED"). `oamSet()` is now cheap; use it
+ * freely. For extreme sprite counts the `oamSetFast()` / `oamSetXYFast()` macros
+ * (see "Fast Macro Sprite API" below) trim a little more overhead.
  *
  * @warning **Coordinate Variable Pattern**: Due to a compiler quirk, sprite
  * coordinates MUST be stored in a struct with s16 members for correct behavior.

--- a/lib/include/snes/types.h
+++ b/lib/include/snes/types.h
@@ -29,11 +29,12 @@
  * @defgroup types Fixed-Width Types
  * @brief Integer types with guaranteed sizes
  *
- * On the 65816 CPU (cproc compiler):
- * - char = 8 bits
+ * On the 65816 CPU (cproc compiler), since chantier A1 (2026-05-08):
+ * - char  = 8 bits
  * - short = 16 bits
- * - int = 32 bits (4 bytes)
- * - long = 64 bits (8 bytes — NOT 32-bit!)
+ * - int   = 16 bits (2 bytes)
+ * - long  = 32 bits (4 bytes)
+ * (see compiler/cproc/type.c — `typeint` size 2, `typelong` size 4.)
  *
  * Always use these typedefs instead of C primitive types.
  * @{

--- a/lib/include/snes/video.h
+++ b/lib/include/snes/video.h
@@ -7,8 +7,6 @@
  *
  * @author OpenSNES Team
  * @copyright MIT License
- *
- * @todo Implement video functions
  */
 
 #ifndef OPENSNES_VIDEO_H


### PR DESCRIPTION
Implements **TIER 1** of the 3-agent audit (reports in /tmp). Doc/comment + lint-tooling only — **no SDK behaviour change**.

### Fixes (newcomer-facing)
- **Phantom API**: GETTING_STARTED "your first program" called `consoleDrawText()` (doesn't exist → won't link) → `textModeInit()`/`textPrintAt()` + matching `LIB_MODULES`. Name purged from examples/README + EXAMPLES_BY_CATEGORY.
- **`oamSet` @warning de-staled**: framesize=158 jitter cliff is RESOLVED (KNOWN_LIMITATIONS) — stop warning against the main sprite API.
- **int/long sizes** in `types.h` + `CLAUDE.md` corrected to post-A1 truth (int=2, long=4; verified in `compiler/cproc/type.c`).
- **TROUBLESHOOTING**: `oamSet` 8-arg→7-arg; `audioPlaySample` bogus sig → real `audioInit`/`audioLoadSample`/`audioPlaySample` flow.
- Example count 54/52→**56** across 6 docs; `sa1_hello` comment 0xA1→0xA5; `video.h` stale `@todo` removed.

### Sentinel hardening (`check_doc_drift.py`) — prevents recurrence
- **Check 5 phantom-API**: a function called in a GETTING_STARTED/TROUBLESHOOTING C snippet must exist in the headers. Comment/cast/UPPER-macro/local/stdlib-safe → never false-fails.
- **Check 3 counts** extended (targeted phrasings + onboarding docs; not bare → "12 examples were" prose stays safe).
- `test_check_doc_drift.py` (7 cases) + CI step. Manually verified it catches a reintroduced `consoleDrawText` and a wrong count; clean on the corpus.

Validation: lint-docs / lint-asm-abi / lint-vram ✓ · smoke-built hello_world + simple_sprite + sa1_hello ✓ · 7/7 unit tests.