### PR TITLE
refactor(examples,lib): TIER 2 (safe lot) — OBJ_FLIPX, init order, text.h unit warning

### DIFF
--- a/examples/games/likemario/main.c
+++ b/examples/games/likemario/main.c
@@ -407,7 +407,7 @@ static void mario_init(void) {
 
     oambuffer[0].oamframeid = FRAME_STAND;
     oambuffer[0].oamrefresh = 1;
-    oambuffer[0].oamattribute = OBJ_PRIO(3) | 0x40;
+    oambuffer[0].oamattribute = OBJ_PRIO(3) | OBJ_FLIPX;
     OAM_SET_GFX_BANK(0, mario_sprite_til, getSpriteTilBank());
 }
 
@@ -432,7 +432,7 @@ static void mario_handle_input(void) {
         if (mario_xvel < -MARIO_MAXACCEL)
             mario_xvel = -MARIO_MAXACCEL;
     } else if (pad & KEY_RIGHT) {
-        oambuffer[0].oamattribute = OBJ_PRIO(3) | 0x40;
+        oambuffer[0].oamattribute = OBJ_PRIO(3) | OBJ_FLIPX;
         if (mario_action == MARIO_ACT_STAND)
             mario_action = MARIO_ACT_WALK;
         mario_xvel += MARIO_ACCEL;

--- a/examples/games/mapandobjects/koopatroopa.c
+++ b/examples/games/mapandobjects/koopatroopa.c
@@ -76,8 +76,8 @@ static void koopatroopa_animate(u16 idx) {
             objWorkspace.sprflip = 1;
             objWorkspace.xvel = +KOOPATROOPA_XVELOC;
             objWorkspace.yvel = 0;
-            oambuffer[n].oamattribute |= 0x40;
-            oambuffer[n + 1].oamattribute |= 0x40;
+            oambuffer[n].oamattribute |= OBJ_FLIPX;
+            oambuffer[n + 1].oamattribute |= OBJ_FLIPX;
         } else {
             objWorkspace.xvel = -KOOPATROOPA_XVELOC;
         }
@@ -87,8 +87,8 @@ static void koopatroopa_animate(u16 idx) {
             objWorkspace.sprflip = 0;
             objWorkspace.xvel = -KOOPATROOPA_XVELOC;
             objWorkspace.yvel = 0;
-            oambuffer[n].oamattribute &= ~0x40;
-            oambuffer[n + 1].oamattribute &= ~0x40;
+            oambuffer[n].oamattribute &= ~OBJ_FLIPX;
+            oambuffer[n + 1].oamattribute &= ~OBJ_FLIPX;
         } else {
             objWorkspace.xvel = +KOOPATROOPA_XVELOC;
         }

--- a/examples/graphics/sprites/simple_sprite/main.c
+++ b/examples/graphics/sprites/simple_sprite/main.c
@@ -52,6 +52,7 @@ extern u8 palsprite32[];
  */
 int main(void) {
     consoleInit();
+    setMode(BG_MODE1, 0);  /* set the video mode up front, before VRAM/OAM setup */
 
     /* DMA sprite tiles to VRAM word address $2100.
      * WaitForVBlank() ensures we are in VBlank when the DMA runs, because
@@ -81,10 +82,9 @@ int main(void) {
      * Visibility is controlled by Y position; oamSet above placed it on-screen. */
     oamSetSize(0, OBJ_LARGE);
 
-    /* Enable Mode 1 with only the OBJ (sprite) layer visible.
-     * No background layers are enabled, so the backdrop color (CGRAM 0) fills
-     * the rest of the screen. */
-    setMode(BG_MODE1, 0);
+    /* Show only the OBJ (sprite) layer; no BG layers are enabled, so the
+     * backdrop colour (CGRAM 0) fills the rest of the screen.
+     * setScreenOn() is always last. */
     setMainScreen(LAYER_OBJ);
     setScreenOn();
 

--- a/examples/maps/slopemario/mario.c
+++ b/examples/maps/slopemario/mario.c
@@ -92,7 +92,7 @@ void marioupdate(u16 idx) {
         if (pad0 & KEY_LEFT) {
             if ((marioflp > 3) || (marioflp < 2))
                 marioflp = 2;
-            oambuffer[0].oamattribute &= ~0x40;  /* no H-flip */
+            oambuffer[0].oamattribute &= ~OBJ_FLIPX;  /* no H-flip */
 
             objWorkspace.action = ACT_WALK;
             objWorkspace.xvel -= MARIO_ACCEL;
@@ -102,7 +102,7 @@ void marioupdate(u16 idx) {
         if (pad0 & KEY_RIGHT) {
             if ((marioflp > 3) || (marioflp < 2))
                 marioflp = 2;
-            oambuffer[0].oamattribute |= 0x40;   /* H-flip */
+            oambuffer[0].oamattribute |= OBJ_FLIPX;   /* H-flip */
 
             objWorkspace.action = ACT_WALK;
             objWorkspace.xvel += MARIO_ACCEL;

--- a/lib/include/snes/text.h
+++ b/lib/include/snes/text.h
@@ -57,6 +57,14 @@ extern TextConfig text_config;
  * @param font_tile    Tile number of the first font glyph in VRAM
  *                     (use TEXT_DEFAULT_FONT_TILE for tile 0)
  * @param palette      Palette slot 0-7 (use TEXT_DEFAULT_PALETTE for 0)
+ *
+ * @warning UNIT MISMATCH (the SDK's one documented inconsistency): this
+ *          `tilemap_addr` is a **byte** address, whereas the rest of the SDK —
+ *          `dmaCopyVram`, `bgSetGfxPtr`/`bgSetMapPtr`, the `oam*` calls, and even
+ *          `textLoadFont()` just below — all take **word** addresses. If you have
+ *          a word address `W` (e.g. from a `vram_map.h` or a VRAM map), pass
+ *          `W * 2` here. Prefer `TEXT_DEFAULT_TILEMAP_ADDR` when you don't need a
+ *          custom slot.
  */
 void textInit(u16 tilemap_addr, u16 font_tile, u8 palette);
 


### PR DESCRIPTION
TIER 2 of the 3-agent audit — the **safe, zero-/low-risk lot**. No behaviour change (identical fbhash, visual 56/56, probes 14/14).

- **OBJ_FLIPX**: raw `0x40` H-flip on `oamattribute` → the existing `OBJ_FLIPX` constant (== 0x40), 8 sites (likemario, mapandobjects/koopatroopa, slopemario/mario). Readability only; compiled bytes unchanged.
- **simple_sprite init order**: `setMode()` moved to right after `consoleInit()` (was after oamInit/dmaCopyVram — worked only via force-blank) to match the canonical order the docs teach. #3 in the learning path.
- **text.h `@warning`**: `textInit()`'s `tilemap_addr` is a *byte* address while the rest of the SDK (dma/bg/oam, and `textLoadFont` right below) takes *word* addresses — the SDK's one documented unit inconsistency. Documented prominently, **not changed** (an API flip would break every caller).

### Deferred (flagged for your call — bigger/riskier)
- Generalising the `vram_map.h` idiom across the ~25 raw-VRAM examples (per-example edit + visual verify + force-add).
- An `oamSetFast` demo in a perf example (kept out of the intro sprite example on purpose).
- Any actual `text.h` byte→word API change (breaking).

Validation: build + visual 56/56 on the 4 changed examples · probes 14/14 · lint-docs / lint-asm-abi clean.