### PR TITLE
refactor(lib,examples): TIER 3 — name VMAIN + screen-dimension magic numbers

### DIFF
--- a/examples/basics/collision_demo/main.c
+++ b/examples/basics/collision_demo/main.c
@@ -259,7 +259,7 @@ static void draw_tilemap(void) {
     u16 addr;
     u8 tile;
 
-    REG_VMAIN = 0x80;
+    REG_VMAIN = VMAIN_INC1;
 
     /* Clear entire 32x32 tilemap at $0400 with tile 0 (empty) */
     dmaFillVRAM(0, VRAM_BG_TILEMAP, 1024 * 2);

--- a/examples/games/likemario/main.c
+++ b/examples/games/likemario/main.c
@@ -229,7 +229,7 @@ static void write_vram_column(u16 map_col, u16 vram_col) {
         base = VRAM_BG_MAP + 0x0400 + (vram_col - 32);
 
     /* Caller must ensure force blank or VBlank */
-    REG_VMAIN = 0x81;
+    REG_VMAIN = VMAIN_INC32;
     REG_VMADDL = base & 0xFF;
     REG_VMADDH = base >> 8;
 
@@ -243,7 +243,7 @@ static void write_vram_column(u16 map_col, u16 vram_col) {
         REG_VMDATAH = 0;
     }
 
-    REG_VMAIN = 0x80;
+    REG_VMAIN = VMAIN_INC1;
 }
 
 /**
@@ -329,7 +329,7 @@ static void map_flush_column(void) {
     if (!col_pending) return;
 
     /* Set VRAM address and vertical column mode (increment by 32 words) */
-    REG_VMAIN = 0x81;
+    REG_VMAIN = VMAIN_INC32;
     REG_VMADDL = col_vram_base & 0xFF;
     REG_VMADDH = col_vram_base >> 8;
 
@@ -345,7 +345,7 @@ static void map_flush_column(void) {
     REG_DASH(1) = 0;
     REG_MDMAEN  = 0x02;            /* Fire DMA channel 1 */
 
-    REG_VMAIN = 0x80;
+    REG_VMAIN = VMAIN_INC1;
     col_pending = 0;
 }
 

--- a/examples/input/two_players/main.c
+++ b/examples/input/two_players/main.c
@@ -153,13 +153,13 @@ int main(void) {
 
         /* Player 1 movement */
         if (pad1 & KEY_UP)    { if (p1.y > 0) p1.y--; }
-        if (pad1 & KEY_DOWN)  { if (p1.y < 224) p1.y++; }
+        if (pad1 & KEY_DOWN)  { if (p1.y < SCREEN_HEIGHT) p1.y++; }
         if (pad1 & KEY_LEFT)  { if (p1.x > 0) p1.x--; }
         if (pad1 & KEY_RIGHT) { if (p1.x < 248) p1.x++; }
 
         /* Player 2 movement */
         if (pad2 & KEY_UP)    { if (p2.y > 0) p2.y--; }
-        if (pad2 & KEY_DOWN)  { if (p2.y < 224) p2.y++; }
+        if (pad2 & KEY_DOWN)  { if (p2.y < SCREEN_HEIGHT) p2.y++; }
         if (pad2 & KEY_LEFT)  { if (p2.x > 0) p2.x--; }
         if (pad2 & KEY_RIGHT) { if (p2.x < 248) p2.x++; }
 

--- a/examples/memory/hirom_demo/main.c
+++ b/examples/memory/hirom_demo/main.c
@@ -150,7 +150,7 @@ static const u8 init_palette[] = {
 static void write_tile(u8 x, u8 y, u8 tile) {
     u16 addr;
     addr = TILEMAP_ADDR + y * 32 + x;
-    REG_VMAIN = 0x80;
+    REG_VMAIN = VMAIN_INC1;
     REG_VMADDL = addr & 0xFF;
     REG_VMADDH = addr >> 8;
     REG_VMDATAL = tile;

--- a/lib/include/snes/registers.h
+++ b/lib/include/snes/registers.h
@@ -110,6 +110,12 @@
 
 /** @brief VRAM address increment mode (W) */
 #define REG_VMAIN       (*(vu8*)0x2115)
+/** @brief VMAIN: auto-increment the VRAM address by 1 word after the high-byte
+ *  write ($2119) — the standard word-at-a-time write mode. */
+#define VMAIN_INC1      0x80
+/** @brief VMAIN: auto-increment the VRAM address by 32 words after the high-byte
+ *  write ($2119) — for writing tilemap columns down a 32-wide map. */
+#define VMAIN_INC32     0x81
 
 /** @brief VRAM address low (W) */
 #define REG_VMADDL      (*(vu8*)0x2116)

--- a/lib/include/snes/video.h
+++ b/lib/include/snes/video.h
@@ -15,6 +15,15 @@
 #include <snes/types.h>
 
 /*============================================================================
+ * Screen dimensions (NTSC visible area)
+ *============================================================================*/
+
+/** @brief Visible screen width in pixels. */
+#define SCREEN_WIDTH   256
+/** @brief Visible screen height in pixels (NTSC, 224 lines). */
+#define SCREEN_HEIGHT  224
+
+/*============================================================================
  * Background Modes
  *============================================================================*/
 


### PR DESCRIPTION
TIER 3 of the audit — named-constant polish. **No behaviour change** (constants ≡ the literals; visual 56/56, identical compiled output).

- **registers.h**: `VMAIN_INC1` (0x80 — +1 word after the $2119 high-byte write, the standard mode) and `VMAIN_INC32` (0x81 — +32 words, tilemap-column writes). Replaces raw `REG_VMAIN = 0x80/0x81` at 6 sites (collision_demo, hirom_demo, likemario ×4) — the silent VRAM-corruption class.
- **video.h**: `SCREEN_WIDTH` (256) / `SCREEN_HEIGHT` (224); two_players Y clamps use `SCREEN_HEIGHT`.

### Deliberately out of scope
- Routing one-off BGR555 colours (`0x7FFF /* white */`) through `RGB()` — already commented + clear; conversion would be hollow and risks a wrong triple.
- Struct-wrapping >3-arg functions — an API design change, not polish (deferred).

Validation: `make clean && make` + full suite — visual 56/56, A7 18/18, probes 14/14, lints clean.