### PR TITLE
fix(docs): correct oamSet signature + de-stale framesize in tutorials

### DIFF
--- a/docs/tutorials/animation.md
+++ b/docs/tutorials/animation.md
@@ -425,7 +425,7 @@ Background tile animation involves VRAM writes, which **must happen during VBlan
 
 ## Performance Considerations
 
-1. **oamSet() is expensive** (framesize=158). For more than 2-3 sprites per frame, use `oamSetFast()` or write directly to `oamMemory[]`
+1. **oamSet() is cheap** — the old framesize=158 cliff was resolved (see `KNOWN_LIMITATIONS.md`); use it freely. For extreme sprite counts, `oamSetFast()` / `oamSetXYFast()` or direct `oamMemory[]` writes trim a little more
 2. **Only set `oamrefresh = 1` when the frame changes** -- redundant VRAM uploads waste VBlank time
 3. **The dynamic engine uploads up to 7 sprites per frame**. If you need more animated sprites, spread their refresh across multiple frames
 4. **BG tile animation competes with sprite DMA for VBlank time**. Budget carefully: ~4 KB total per VBlank

--- a/docs/tutorials/input.md
+++ b/docs/tutorials/input.md
@@ -187,7 +187,7 @@ while (1) {
 
     // Update sprites
     oamSet(0, p1_x, p1_y, 0, 0, 0, 0);  // Player 1
-    oamSet(1, p2_x, p2_y, 0, 0, 0, 1);  // Player 2
+    oamSet(1, p2_x, p2_y, 0, 1, 0, 0);  // Player 2 (palette 1)
     oamUpdate();
 }
 ```

--- a/docs/tutorials/sprites.md
+++ b/docs/tutorials/sprites.md
@@ -54,9 +54,9 @@ int main(void) {
 ### Setting a Sprite
 
 ```c
-// oamSet(id, x, y, priority, hflip, vflip, palette)
-oamSet(0, 100, 80, 0, 0, 0, 0);  // Sprite 0 at (100, 80)
-oamSet(1, 120, 80, 0, 0, 0, 1);  // Sprite 1 with palette 1
+// oamSet(id, x, y, tile, palette, priority, flags)
+oamSet(0, 100, 80, 0, 0, 0, 0);  // Sprite 0 at (100, 80), tile 0
+oamSet(1, 120, 80, 0, 1, 0, 0);  // Sprite 1 with palette 1
 ```
 
 ### Updating OAM
@@ -179,8 +179,8 @@ void update_player(u16 pad) {
         facing_right = 1;
     }
 
-    // Update sprite with horizontal flip based on direction
-    oamSet(0, player_x, player_y, 0, !facing_right, 0, 0);
+    // Update sprite with horizontal flip based on direction (flip = flags arg)
+    oamSet(0, player_x, player_y, 0, 0, 0, facing_right ? 0 : OBJ_FLIPX);
 }
 ```
 


### PR DESCRIPTION
Doc-currency check before v0.23.0 surfaced stale API in the **tutorials** — the DX audit covered GETTING_STARTED/TROUBLESHOOTING + headers but not these.

- **sprites.md / input.md**: `oamSet()` examples used the old PVSnesLib order `(id, x, y, priority, hflip, vflip, palette)`. The real API is `(id, x, y, tile, palette, priority, flags)` — the snippets set *flip* where they meant *palette*. Fixed the signature comment + the calls (palette → arg 5; H-flip → `OBJ_FLIPX` in flags).
- **animation.md**: dropped the stale "oamSet() is expensive (framesize=158)" note — resolved cliff (KNOWN_LIMITATIONS), same as the sprite.h fix in TIER 1.

Pure docs; `lint-docs` green. `animation.md:197`'s oamSet was already correct.

Note: tutorials carry illustrative pseudo-code, so they're not under the phantom-API sentinel (false-positive risk) — they need periodic manual review.