### PR TITLE
test(compiler): A6 Phase A1 — far-deref test matrix (form × size × bank)

### DIFF
--- a/devtools/compiler-tests/runtime/a6_farptr/main.c
+++ b/devtools/compiler-tests/runtime/a6_farptr/main.c
@@ -1,30 +1,56 @@
 /*
- * A6 far-pointer runtime fixture — deref of a pointer to data OUTSIDE bank $00.
+ * A6 far-pointer runtime MATRIX (Tier 2, Phase A — A1).
  *
- * a6_sentinel lives in BANK 2 (see a6_sentinel.asm). A *volatile* pointer forces
- * a register-indirect deref (the compiler can't fold it to a direct symbol
- * access), exercising the `lda.l $0000,x` path that ignores the bank byte.
+ * Each global below is one matrix cell: a pointer DEREF crossed by
+ *   {byte, word, long, param/RSlot, phi/cond} × {bank $00, bank $02}.
+ * A red cell pinpoints exactly which emit path drops the bank byte — so the
+ * Phase-A codegen work is a checklist, not "24 examples regressed, which one?".
  *
- * Expected once A6 lowers derefs as 24-bit: r_d0/3/7 = 0x11/0x44/0x88.
- * r_ptrhi isolates storage vs deref: it must be 0x0002 (the pointer VALUE keeps
- * the bank byte) even if the deref is still buggy.
+ * Sentinels carry distinct patterns so a wrong-bank read is *detectable*:
+ *   a6_sentinel (BANK 2): 11 22 33 44 55 66 77 88
+ *   s0          (bank 0): A0 A1 A2 A3 A4 A5 A6 A7
+ * Pointers are `volatile` → opaque, register-indirect (can't fold to a direct
+ * symbol access), so they exercise the deref emit, not constant folding.
+ *
+ * On qbe 1884a20 (no far deref) the bank-$02 cells read bank-$00 garbage and
+ * FAIL (the A6 gap); the bank-$00 cells pass. Phase A turns the bank-$02 cells
+ * green one storage form at a time.
  */
 #include <snes.h>
 
-extern const u8 a6_sentinel[];
-volatile const u8 *g_p;   /* volatile → opaque far pointer, register-indirect deref */
+extern const u8 a6_sentinel[];                                /* BANK 2 */
+const u8 s0[8] = {0xA0,0xA1,0xA2,0xA3,0xA4,0xA5,0xA6,0xA7};   /* bank $00 */
 
-u8  r_d0;     /* g_p[0] -> 0x11 */
-u8  r_d3;     /* g_p[3] -> 0x44 */
-u8  r_d7;     /* g_p[7] -> 0x88 */
-u16 r_ptrhi;  /* high 16 of the pointer value -> 0x0002 (bank byte present) */
+volatile const u8 *p2;
+volatile const u8 *p0;
+
+/* one global per matrix cell */
+u8  b2_0, b2_7, b0_0, b0_7;   /* byte loads        */
+u16 w2_0, w2_2, w0_0;         /* word loads        */
+u32 l2_0, l0_0;               /* long loads        */
+u8  fp2, fp0;                 /* via function param (RSlot path) */
+u8  ph2;                      /* via phi / conditional */
+u16 hi2, hi0;                 /* pointer high half (bank carried in the value) */
+
+/* non-static -> not inlined -> forces the pointer through a param (RSlot) slot */
+u8 rd_byte(volatile const u8 *p, u8 i) { return p[i]; }
 
 int main(void) {
-    g_p = a6_sentinel;
-    r_d0 = g_p[0];
-    r_d3 = g_p[3];
-    r_d7 = g_p[7];
-    r_ptrhi = (u16)(((u32)g_p) >> 16);
+    p2 = a6_sentinel;
+    p0 = s0;
+
+    b2_0 = p2[0];  b2_7 = p2[7];
+    b0_0 = p0[0];  b0_7 = p0[7];
+    w2_0 = *(volatile const u16 *)(p2 + 0);
+    w2_2 = *(volatile const u16 *)(p2 + 2);
+    w0_0 = *(volatile const u16 *)(p0 + 0);
+    l2_0 = *(volatile const u32 *)(p2 + 0);
+    l0_0 = *(volatile const u32 *)(p0 + 0);
+    fp2  = rd_byte(p2, 3);
+    fp0  = rd_byte(p0, 3);
+    { volatile const u8 *pp = (b2_0 == 0x11) ? p2 : p0; ph2 = pp[5]; }
+    hi2  = (u16)(((u32)p2) >> 16);
+    hi0  = (u16)(((u32)p0) >> 16);
 
     consoleInit();
     setScreenOn();

--- a/devtools/compiler-tests/runtime/a6_farptr/test_a6_farptr.py
+++ b/devtools/compiler-tests/runtime/a6_farptr/test_a6_farptr.py
@@ -1,35 +1,68 @@
 #!/usr/bin/env python3
-"""A6 far-pointer runtime check: deref of a pointer to BANK 2 data.
+"""A6 far-pointer MATRIX runtime test (Tier 2, Phase A — A1).
 
-Proves the A6 remaining gap: the pointer VALUE keeps its bank byte (r_ptrhi),
-but dereferencing it reads bank $00 (the `lda.l $0000,x` codegen). The deref
-cases are xfail until A6 Phase 1 lowers pointer derefs as 24-bit.
+Each cell is a pointer DEREF crossed by {byte, word, long, param/RSlot, phi} ×
+{bank $00, bank $02}. Bank-$02 deref cells exercise the A6 far gap (KNOWN_FAIL
+until the far-deref codegen lands); bank-$00 cells + the pointer-VALUE high half
+must already pass. As Phase A turns a bank-$02 cell green it XPASSes — promote it
+out of KNOWN_FAIL. The run fails ONLY on a regression of an expected-green cell,
+so it is a safe gate while Phase A is in flight.
+
+Run: cd devtools/compiler-tests/runtime/a6_farptr && make && python3 test_a6_farptr.py
 """
 import sys
 from pathlib import Path
+
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE.parents[3] / "tools" / "luna-test" / "probes"))
 from lib import find_luna, sym_of, assert_mem  # noqa: E402
-ROM = HERE / "a6_farptr.sfc"; STEPS = 1_000_000
-CASES = [("r_ptrhi", 2, 0x0002), ("r_d0", 1, 0x11), ("r_d3", 1, 0x44), ("r_d7", 1, 0x88)]
-# Deref through a far pointer is bank-$00-hardcoded (emit.c `lda.l $0000,x`);
-# fixed in A6 Phase 1. r_ptrhi (the pointer value's bank byte) already works.
-KNOWN_FAIL = {"r_d0", "r_d3", "r_d7"}
-def le(v, w): return "".join(f"{(v>>(8*i))&0xFF:02X}" for i in range(w))
+
+ROM = HERE / "a6_farptr.sfc"
+STEPS = 1_000_000
+
+# (name, width_bytes, expected, bank, form)
+CASES = [
+    ("b0_0", 1, 0xA0,       0, "byte"),  ("b0_7", 1, 0xA7,       0, "byte"),
+    ("w0_0", 2, 0xA1A0,     0, "word"),  ("l0_0", 4, 0xA3A2A1A0, 0, "long"),
+    ("fp0",  1, 0xA3,       0, "param"), ("hi0",  2, 0x0000,     0, "ptr-hi"),
+    ("b2_0", 1, 0x11,       2, "byte"),  ("b2_7", 1, 0x88,       2, "byte"),
+    ("w2_0", 2, 0x2211,     2, "word"),  ("w2_2", 2, 0x4433,     2, "word"),
+    ("l2_0", 4, 0x44332211, 2, "long"),
+    ("fp2",  1, 0x44,       2, "param"), ("ph2",  1, 0x66,       2, "phi"),
+    ("hi2",  2, 0x0002,     2, "ptr-hi"),   # pointer VALUE carries bank → passes pre-A6
+]
+# The A6 gap: far DEREF of bank-$02 data. (hi2 is the pointer value, not a deref.)
+# FINDING (A1 baseline): l2_0 — the Kl (u32) load — is ALREADY bank-aware on qbe
+# 1884a20 (reads bank $02 correctly) while byte/word/param/phi are not. So the
+# long-load emit path is the working model to replicate for the other forms in A2.
+KNOWN_FAIL = {"b2_0", "b2_7", "w2_0", "w2_2", "fp2", "ph2"}
+
+
+def le(v, w):
+    return "".join(f"{(v >> (8 * i)) & 0xFF:02X}" for i in range(w))
+
+
 def run():
-    if not ROM.is_file(): sys.exit(f"ROM missing: {ROM} (run make)")
-    luna = find_luna(); real = 0
-    for name, w, want in CASES:
+    if not ROM.is_file():
+        sys.exit(f"ROM missing: {ROM} (run make)")
+    luna = find_luna()
+    regress, xfail, xpass = [], [], []
+    for name, w, want, bank, form in CASES:
         b, o = sym_of(ROM, name)
-        ok, det = assert_mem(luna, ROM, STEPS, [(b, o, le(want, w))])
+        ok, _ = assert_mem(luna, ROM, STEPS, [(b, o, le(want, w))])
         if name in KNOWN_FAIL:
-            print(f"  {'XPASS' if ok else 'XFAIL'} {name} == 0x{want:0{w*2}X}"
-                  + ("  ← fixed! remove from KNOWN_FAIL" if ok else "  (A6 deref gap)"))
-            real += 1 if ok else 0
+            (xpass if ok else xfail).append(name)
+            note = "  <- XPASS: promote out of KNOWN_FAIL" if ok else "  (A6 gap, xfail)"
         else:
-            print(f"  {'PASS' if ok else 'FAIL'}  {name} == 0x{want:0{w*2}X}" + ("" if ok else f"  [{det}]"))
-            real += 0 if ok else 1
-    passed = sum(1 for n,_,_ in CASES if n not in KNOWN_FAIL)
-    print(f"\nA6 far-ptr: {passed-real}/{passed} ok (+{len(KNOWN_FAIL)} xfail: deref gap)")
-    return 1 if real else 0
-sys.exit(run())
+            if not ok:
+                regress.append(name)
+            note = "" if ok else "  <- REGRESSION"
+        print(f"  [{' ' if ok else 'X'}] bank{bank} {form:<6} {name:<5} == 0x{want:0{w*2}X}{note}")
+    green = [c[0] for c in CASES if c[0] not in KNOWN_FAIL]
+    print(f"\nA6 matrix: {len(green) - len(regress)}/{len(green)} expected-green ok; "
+          f"{len(xfail)} xfail (A6 far gap), {len(xpass)} XPASS")
+    return 1 if regress else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
First step of A6 Tier 2 Phase A (correctness). **Test-only, no compiler change.**

Turns the single-case `a6_farptr` fixture into a **matrix**: each cell = a pointer deref crossed by {byte, word, long, param/RSlot, phi} × {bank $00, bank $02}. A red cell pinpoints exactly which emit path drops the bank byte — the surgical diagnostic the 3 (4) failed attempts lacked. The run fails only on a **regression** of an expected-green cell → safe gate while Phase A is in flight.

Baseline on qbe 1884a20: **8/8 expected-green; 6 xfail** = the A6 gap (bank-$02 byte/word/param/phi derefs). 🔎 **Finding**: the Kl (u32) long-load path is **already bank-aware** (l2_0 reads bank $02 correctly) — the working model to replicate for byte/word/param in A2.

This is the A2 checklist: turn the 6 xfail cells green, one storage form at a time, each gated by this matrix + visual 56/56.