### PR TITLE
ci(release): add Linux arm64 (aarch64) build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
           - os: ubuntu-latest
             name: linux
             arch: x86_64
+          - os: ubuntu-24.04-arm
+            name: linux
+            arch: arm64
           - os: windows-latest
             name: windows
             arch: x86_64
@@ -211,6 +214,7 @@ jobs:
           | Platform | File | Architecture |
           |----------|------|--------------|
           | **Linux** | \`opensnes_${TAG}_linux_x86_64.zip\` | x86_64 |
+          | **Linux** | \`opensnes_${TAG}_linux_arm64.zip\` | arm64 (aarch64) |
           | **macOS** | \`opensnes_${TAG}_darwin_arm64.zip\` | arm64 (Apple Silicon) |
           | **Windows** | \`opensnes_${TAG}_windows_x86_64.zip\` | x86_64 (MSYS2 UCRT64) |
 
@@ -233,5 +237,6 @@ jobs:
           prerelease: ${{ contains(steps.tag.outputs.version, '-rc') || contains(steps.tag.outputs.version, '-beta') }}
           files: |
             artifacts/opensnes-${{ steps.tag.outputs.version }}-linux-x86_64/opensnes_${{ steps.tag.outputs.version }}_linux_x86_64.zip
+            artifacts/opensnes-${{ steps.tag.outputs.version }}-linux-arm64/opensnes_${{ steps.tag.outputs.version }}_linux_arm64.zip
             artifacts/opensnes-${{ steps.tag.outputs.version }}-darwin-arm64/opensnes_${{ steps.tag.outputs.version }}_darwin_arm64.zip
             artifacts/opensnes-${{ steps.tag.outputs.version }}-windows-x86_64/opensnes_${{ steps.tag.outputs.version }}_windows_x86_64.zip


### PR DESCRIPTION
Adds an `ubuntu-24.04-arm` runner to the release matrix so each tagged release ships a native Linux aarch64 SDK package alongside x86_64/macOS/Windows.

- arch label is `arm64` to match the Makefile (`uname -m` aarch64 → `ARCH := arm64`), so `make release` emits `opensnes_<tag>_linux_arm64.zip` and the upload/publish paths resolve.
- publish job: download table + release `files:` list gain the new artifact.
- arm64 hosted runners are GA and free for public repos (repo is PUBLIC).

Class D (CI only) — no ROM bytes change.