### PR TITLE
feat: ship the opensnes project CLI (init/build/run/doctor)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,13 +54,13 @@ else
 endif
 
 .DEFAULT_GOAL := all
-.PHONY: all clean install compiler tools lib examples tests test-compiler test-wram bench submodules verify-toolchain lint-commits lint-docs lint-asm-abi lint-vram lint docs help release clean-release
+.PHONY: all clean install compiler tools lib examples cli tests test-compiler test-wram bench submodules verify-toolchain lint-commits lint-docs lint-asm-abi lint-vram lint docs help release clean-release
 
 #------------------------------------------------------------------------------
 # Main targets
 #------------------------------------------------------------------------------
 
-all: submodules compiler tools lib examples
+all: submodules compiler tools lib examples cli
 	@echo ""
 	@echo "=========================================="
 	@echo "OpenSNES SDK build complete!"
@@ -73,9 +73,18 @@ clean:
 	$(MAKE) -C $(EXAMPLES_PATH) clean
 	-rm -rf bin/
 
-install: compiler tools lib
+install: compiler tools lib cli
 	$(MAKE) -C $(COMPILER_PATH) install
 	$(MAKE) -C $(TOOLS_PATH) install
+
+# Install the `opensnes` project CLI (init/build/run/doctor) into bin/ so it
+# ships in the dev tree and, via the release target's `cp -r bin/*`, in the
+# release zip. The CLI resolves the SDK root from its own bin/ location.
+cli:
+	@mkdir -p bin
+	@cp scripts/opensnes bin/opensnes
+	@chmod +x bin/opensnes
+	@echo "Installed CLI: bin/opensnes  (run 'bin/opensnes doctor')"
 
 #------------------------------------------------------------------------------
 # Components

--- a/README.md
+++ b/README.md
@@ -135,7 +135,15 @@ make
 
 Open `examples/text/hello_world/hello_world.sfc` in [Mesen2](https://www.mesen.ca/) and you're running on a Super Nintendo.
 
-For prerequisites and platform-specific setup, see the **[Getting Started guide](https://k0b3n4irb.github.io/opensnes/getting_started.html)**.
+To start your own game, the build installs an `opensnes` CLI in `bin/`:
+
+```bash
+bin/opensnes init my-game --template game   # scaffolds a working project
+cd my-game && ../bin/opensnes run           # builds and launches your emulator
+```
+
+`opensnes doctor` checks your toolchain, library, and emulator. For prerequisites
+and platform-specific setup, see the **[Getting Started guide](https://k0b3n4irb.github.io/opensnes/getting_started.html)**.
 
 ## Examples
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -61,7 +61,7 @@ Download the latest release for your platform from the
 | Platform | File |
 |----------|------|
 | Linux x86_64 | `opensnes_<version>_linux_x86_64.zip` |
-| Linux aarch64 | `opensnes_<version>_linux_aarch64.zip` |
+| Linux aarch64 | `opensnes_<version>_linux_arm64.zip` |
 | macOS arm64 | `opensnes_<version>_darwin_arm64.zip` |
 | Windows x86_64 | `opensnes_<version>_windows_x86_64.zip` |
 
@@ -84,7 +84,37 @@ You should see "Hello World!" on screen.
 
 ### A5. Create Your Own Project
 
-Create a new directory anywhere on your machine:
+The SDK ships an **`opensnes` CLI** (in the extracted `bin/` directory) that
+scaffolds, builds, and runs a project for you. Put it on your `PATH` once — from
+the extracted SDK directory:
+
+```bash
+export PATH="$PWD/bin:$PATH"   # add to your shell profile to make it permanent
+```
+
+Then create, build, and run your first project in three commands:
+
+```bash
+opensnes init my-game --template game   # scaffolds Makefile + main.c + res/
+cd my-game
+opensnes run                            # builds the ROM and launches your emulator
+```
+
+`opensnes init` gives you a project that builds and runs from the start. Pick a
+template:
+
+- **`--template blank`** — a "HELLO SNES!" text screen, the simplest starting point.
+- **`--template game`** — a white sprite you move with the D-pad, a starting
+  point for an action game.
+
+Other commands: `opensnes build`, `opensnes clean`, and `opensnes doctor` (checks
+your toolchain, library, and emulator and tells you what is missing). Run
+`opensnes help` for the full list.
+
+#### Manual setup (the long way)
+
+Prefer to wire it by hand, or curious what `init` generates? Create a new
+directory anywhere on your machine:
 
 ```bash
 mkdir ~/my-snes-game

--- a/scripts/opensnes
+++ b/scripts/opensnes
@@ -136,22 +136,12 @@ write_template_blank() {
 #include <snes.h>
 
 int main(void) {
-    consoleInit();
-    setMode(BG_MODE0, 0);
+    /* One call sets up the PPU, the text engine, and the default font. */
+    textModeInit();
 
-    setColor(0, RGB(0, 0, 10));
-    setColor(1, RGB(31, 31, 31));
-    setMainScreen(LAYER_BG1);
+    /* The NMI handler flushes printed text to VRAM automatically. */
+    textPrintAt(9, 14, "HELLO SNES!");
 
-    textInit();
-    textLoadFont(0x0000);
-    bgSetGfxPtr(0, 0x0000);
-    bgSetMapPtr(0, 0x3800, BG_MAP_32x32);
-
-    textPrintAt(8, 14, "HELLO SNES!");
-    textFlush();
-
-    WaitForVBlank();
     setScreenOn();
 
     while (1) {
@@ -169,28 +159,44 @@ write_template_game() {
     cat > "$dir/main.c" << 'MAIN_C'
 #include <snes.h>
 
-static u16 pad;
-static s16 sprite_x = 120;
-static s16 sprite_y = 100;
+/* A single 8x8 4bpp tile. Plane 0 is all-set, planes 1-3 are clear, so every
+ * pixel reads palette index 1 — which we colour white below. */
+static const u8 player_tile[32] = {
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+};
+
+/* Two BGR555 colours: index 0 transparent, index 1 white ($7FFF). */
+static const u8 player_pal[4] = { 0x00, 0x00, 0xFF, 0x7F };
+
+static s16 player_x = 120;
+static s16 player_y = 100;
 
 int main(void) {
     consoleInit();
+    WaitForVBlank();
 
-    oamClear();
+    /* Upload the sprite tile to VRAM and its palette to the sprite CGRAM. */
+    dmaCopyVram((u8 *)player_tile, 0x4000, sizeof player_tile);
+    dmaCopyCGram((u8 *)player_pal, OBJ_CGRAM_BASE, sizeof player_pal);
 
+    REG_OBJSEL = OBJSEL(OBJ_SIZE8_L16, 0x4000);
+    oamInit(OBJ_SIZE8_L16, 1);
+    setMainScreen(LAYER_OBJ);
     setScreenOn();
 
     while (1) {
+        u16 pad = padHeld(0);
+
+        if (pad & KEY_UP)    player_y--;
+        if (pad & KEY_DOWN)  player_y++;
+        if (pad & KEY_LEFT)  player_x--;
+        if (pad & KEY_RIGHT) player_x++;
+
+        oamSet(0, player_x, player_y, 0, 0, 3, 0);
         WaitForVBlank();
-
-        pad = padHeld(0);
-
-        if (pad & KEY_UP)    sprite_y--;
-        if (pad & KEY_DOWN)  sprite_y++;
-        if (pad & KEY_LEFT)  sprite_x--;
-        if (pad & KEY_RIGHT) sprite_x++;
-
-        oamSet(0, sprite_x, sprite_y, 0, 0, 0, 0);
     }
 
     return 0;
@@ -200,8 +206,8 @@ MAIN_C
 
 lib_modules_for_template() {
     case "$1" in
-        blank) echo "console dma text background sprite" ;;
-        game)  echo "console sprite dma input" ;;
+        blank) echo "console dma text background" ;;
+        game)  echo "console sprite dma input background" ;;
         *)     die "Unknown template: $1" ;;
     esac
 }


### PR DESCRIPTION
Audit follow-up — the highest-impact DX item: the `opensnes` starter CLI already existed (`scripts/opensnes`: `init` / `build` / `run` / `doctor`, two templates) but was **never installed or documented**, and its `blank` template **didn't compile** against the current text API. The flagship "start your own game" path was invisible and broken.

## Changes
- **`make cli`** copies `scripts/opensnes` → `bin/opensnes`, wired into `all` + `install`. Since `make release` does `cp -r bin/*`, the CLI now ships in the dev tree **and** the release zip. It self-resolves the SDK root from its own `bin/` location (no env var needed).
- **Templates fixed & verified** (built via `opensnes init … && make`, both produce a 256 KB ROM):
  - `blank` → modern one-call `textModeInit()` — renders `HELLO SNES!` (luna-verified).
  - `game` → a **visible D-pad-movable sprite** (inline tile + palette + `oamInit`), not an invisible/garbage block.
- **Docs**: GETTING_STARTED "Create Your Own Project" is now CLI-first (`opensnes init/run/doctor`), with the hand-written Makefile+main.c kept as **Manual setup**. README Quick Start mentions the CLI. Fixed the Linux aarch64 release filename in the download table (`arm64`, not `aarch64`).

## Validation
- `opensnes init` + `make` build cleanly for **both** templates; `blank` renders `HELLO SNES!` in luna.
- `bin/opensnes doctor` self-resolves the SDK from `bin/` and reports the toolchain OK.
- `bin/` is gitignored, so only the tracked sources (Makefile, scripts/opensnes, docs) are committed; the binary is produced by the build.
- `make lint-docs` green.

Class A-adjacent (touches the root Makefile `all`/`install` + release packaging) — CI builds exercise it on all platforms.