### PR TITLE
docs: fix dangling references to the removed hdma_gradient example

### DIFF
--- a/docs/EXAMPLES_BY_CATEGORY.md
+++ b/docs/EXAMPLES_BY_CATEGORY.md
@@ -59,7 +59,6 @@ Visual effects using HDMA, color math, and hardware windows.
 | @subpage examples_graphics_effects_fading | Brightness control, screen transitions |
 | @subpage examples_graphics_effects_mosaic | Mosaic pixelation effect |
 | @subpage examples_graphics_effects_hdma_wave | HDMA scanline wave distortion |
-| @subpage examples_graphics_effects_hdma_gradient | HDMA color gradient per scanline |
 | @subpage examples_graphics_effects_hdma_helpers | High-level HDMA effect library (wave, ripple, iris) |
 | @subpage examples_graphics_effects_gradient_colors | HDMA + CGRAM color gradients |
 | @subpage examples_graphics_effects_parallax_scrolling | HDMA parallax scrolling |

--- a/docs/LEARNING_PATH.md
+++ b/docs/LEARNING_PATH.md
@@ -45,8 +45,6 @@ HDMA, parallax, color math, hardware windows.
 
 @subpage examples_graphics_effects_hdma_wave
 
-@subpage examples_graphics_effects_hdma_gradient
-
 @subpage examples_graphics_effects_hdma_helpers
 
 @subpage examples_graphics_effects_gradient_colors

--- a/docs/examples_group.md
+++ b/docs/examples_group.md
@@ -41,7 +41,6 @@ Browse by category: @ref examples_by_category
 - @ref window/main.c "Window" — Clipping regions
 - @ref transparent_window/main.c "Transparent Window" — Window + color math
 - @ref gradient_colors/main.c "Gradient Colors" — HDMA per-scanline palette
-- @ref hdma_gradient/main.c "HDMA Gradient" — Brightness gradient
 - @ref hdma_wave/main.c "HDMA Wave" — Sine distortion
 - @ref hdma_helpers/main.c "HDMA Helpers" — Library helper effects
 - @ref parallax_scrolling/main.c "Parallax" — HDMA scroll offsets

--- a/docs/tutorials/dma.md
+++ b/docs/tutorials/dma.md
@@ -269,14 +269,14 @@ The bank byte for an `extern` symbol resolves at link time as
 extern u8 huge_tileset[];
 /* `:huge_tileset` is the linker-resolved bank — assembly only.
  * From C, you typically build a small assembly helper that knows
- * the bank, like the asm_loadGraphics() helper in
- * examples/graphics/effects/hdma_gradient. */
+ * the bank, like the asm_loadSkyData() helper in
+ * examples/graphics/backgrounds/mode7_perspective. */
 ```
 
 Most projects either (a) keep all assets in bank `$00` (small games),
 or (b) write a small assembly DMA helper per asset to handle the
-correct bank. Both shipped examples that hit this case
-(`hdma_gradient`, `mode7_perspective`) take option (b).
+correct bank. The shipped example that hits this case
+(`mode7_perspective`) takes option (b).
 
 ### 🟠 Channel 0 vs HDMA on channel 0
 

--- a/docs/tutorials/hdma.md
+++ b/docs/tutorials/hdma.md
@@ -2,7 +2,7 @@
 
 This tutorial covers SNES HDMA (Horizontal-blanking DMA): what it is, when
 to reach for it, the four registers per channel, the eight transfer modes,
-and the per-scanline patterns the seven shipped examples exercise. It
+and the per-scanline patterns the six shipped examples exercise. It
 assumes you have already worked through the [Graphics](graphics.md) and
 [Scrolling](scrolling.md) tutorials.
 
@@ -177,21 +177,11 @@ Two things often forgotten:
    before the source/mode/destination are settled gives the PPU a frame
    of garbage HDMA reads.
 
-## Worked patterns (the seven shipped examples)
+## Worked patterns (the six shipped examples)
 
 Every shipped example exercises a distinct HDMA case. Read the
 `@par What to Observe` block at the top of each `main.c` for the
 interactive demo; the patterns themselves are reusable building blocks.
-
-### Background colour gradient — `examples/graphics/effects/hdma_gradient`
-
-Builds a brightness gradient at runtime via the
-`hdmaBrightnessGradient(channel, topBrightness, bottomBrightness)` helper,
-which interpolates between the two values across 224 scanlines and emits
-an HDMA table writing `$2100` (INIDISP) per scanline group. Press **A**
-to cycle gradients; **B** to disable. The 8 bpp Mode 3 background
-underneath shows the smooth fade from full brightness at top to dark at
-bottom.
 
 ### Per-scanline wave distortion — `examples/graphics/effects/hdma_wave`
 
@@ -335,7 +325,6 @@ inner game-logic loops.
 - `lib/include/snes/hdma.h` — full API reference (function signatures,
   mode constants, destination-register constants).
 - `lib/source/hdma.asm` and `lib/source/hdma.c` — implementation.
-- [`examples/graphics/effects/hdma_gradient`](../../examples/graphics/effects/hdma_gradient/README.md) — runtime gradient builder.
 - [`examples/graphics/effects/hdma_wave`](../../examples/graphics/effects/hdma_wave/README.md) — sine-wave per-scanline scroll.
 - [`examples/graphics/effects/hdma_helpers`](../../examples/graphics/effects/hdma_helpers/README.md) — API surface walkthrough.
 - [`examples/graphics/effects/parallax_scrolling`](../../examples/graphics/effects/parallax_scrolling/README.md) — RAM table, two-speed parallax.


### PR DESCRIPTION
Audit follow-up (the P0-3b phantom I'd deferred). The `hdma_gradient` example was removed — superseded by `hdma_helpers` (`hdmaBrightnessGradient()`) and `gradient_colors` — but **six docs still referenced it**, including dead Doxygen `@subpage`/`@ref` anchors and a dead README link.

## Fixes
- **EXAMPLES_BY_CATEGORY / LEARNING_PATH / examples_group**: drop the phantom entries (`hdma_helpers` + `gradient_colors` are already listed right next to them).
- **hdma.md**: remove the phantom "Background colour gradient" worked-pattern section (brightness gradient is covered by the `hdma_helpers` section) and the dead See-also link; fix the count *seven → six shipped examples*.
- **dma.md**: repoint the bank-load-helper illustration from the non-existent `asm_loadGraphics()`/`hdma_gradient` to the real `asm_loadSkyData()` in `mode7_perspective` (verified it exists).

## Validation
- `grep -rn hdma_gradient docs/ --include=*.md` → empty (no source refs remain).
- `make lint-docs` green.
- Class D (docs only).