### PR TITLE
release: v0.27.1

### DIFF
--- a/.claude/STRUCTURAL_DEFECTS.md
+++ b/.claude/STRUCTURAL_DEFECTS.md
@@ -826,7 +826,10 @@ representation in the toolchain.
   half) + a dedicated far-deref scratch — both pervasive, 2–4 weeks, HIGH risk,
   now *cadré* by the new `a6_farptr` test matrix (the per-cell diagnostic the 4
   prior attempts lacked). WIP preserved: qbe `wip/a6-deref-attempt4`,
-  `wip/a6-a2-byte-load`. develop clean (1884a20, 56/56).
+  `wip/a6-a2-byte-load`. develop clean (1884a20, 56/56). Attempt #3 (Ocopy
+  high-half fix, judged insufficient) lived on the opensnes branch
+  `chantier/a6-codegen`, deleted 2026-07-04 per branch policy — its 4 wip
+  commits remain reachable at SHA `bd6ab276` until GC.
 
 - **2026-05-09** — Partial implementation attempted (A6.1 + A6.3) and
   reverted. Diff was 163 lines in `compiler/qbe/w65816/emit.c` adding:

--- a/.claude/notes/chantiers/luna_migration.md
+++ b/.claude/notes/chantiers/luna_migration.md
@@ -4,7 +4,9 @@
 with [luna](https://github.com/k0b3n4irb/luna), a cycle-accurate Rust SNES
 emulator (headless CLI + API + MCP) that natively runs SA-1 / Super FX / DSP-1.
 
-Full pre-migration report (exhaustive): `/tmp/luna_migration_report_2026-06-20.md`.
+(The exhaustive pre-migration report lived at
+`/tmp/luna_migration_report_2026-06-20.md` — a scratch file, gone with the
+machine; this note is the surviving record.)
 
 ## Why (value-add)
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "compiler/wla-dx"]
 	path = compiler/wla-dx
 	url = https://github.com/k0b3n4irb/wla-dx.git
+	ignore = dirty
 [submodule "compiler/cproc"]
 	path = compiler/cproc
 	url = https://github.com/k0b3n4irb/cproc.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to OpenSNES are documented in this file.
 OpenSNES is forked from [PVSnesLib](https://github.com/alekmaul/pvsneslib). This changelog
 covers changes made since the fork.
 
+## [0.27.1] — 2026-07-05
+
+Documentation-site branding and repository housekeeping.
+
+### Added
+- feat(docs): OpenSNES brand theme for the documentation site — palette
+  extracted from the logo (SNES-violet primary in light mode; logo-navy page
+  with terminal-green links in dark mode), the logo's tri-color accent bar as
+  a page-top signature, and the logo + wordmark now present on every page.
+  Every text/background pair verified WCAG AA
+
+### Fixed
+- fix(docs): the docs site rendered a raw "Toggle main menu visibility"
+  checkbox on every page and showed no project name or logo anywhere — the
+  custom Doxygen header had dropped the standard title area and the
+  `tabs.css` link; both restored
+
+### Changed
+- docs: stale migration-era claims retired (luna-test "Phase 1 prototype"
+  framing, dead `/tmp` report links, BENCHMARK.md "currently DISABLED" while
+  the re-homed suite gates CI, contradictory fbhash/SHA-256 phrasing)
+- build: `git status` no longer stays noisy from the pinned wla-dx
+  submodule's in-tree build artifacts (`ignore = dirty`; SHA drift remains
+  guarded by `make verify-toolchain`)
+
 ## [0.27.0] — 2026-07-04
 
 Hardening release, driven by a full project review: silent-failure fixes in

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ and **what is next**.
 
 ---
 
-## Current Status: post-v0.27.0 (developing toward v0.28.0)
+## Current Status: post-v0.27.1 (developing toward v0.28.0)
 
 A modern, well-tested SNES SDK ready for serious hobby development, game jams,
 and educational use, building toward commercial-grade maturity. The compiler
@@ -284,6 +284,6 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for guidelines, branch policy
 (`main` = stable / `develop` = active), and PR rules. Build instructions
 live in [`README.md`](README.md).
 
-*Last updated: 2026-07-04. Anchored claims (version, examples count, framework
+*Last updated: 2026-07-05. Anchored claims (version, examples count, framework
 opt-in list) verified by `make lint-docs` — see `devtools/check_doc_drift.py`
 and `.claude/rules/doc_consistency.md`.*

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -2,9 +2,11 @@
 
 *Last updated: 2026-05-13 (re-baselined post deferred-emit + lib retrofit
 chantier; toolchain pins qbe `988073d`, cproc `42a5c46`).
-Run: (currently **DISABLED** — depended on the removed `opensnes-emu`
-submodule; pending re-home off the old harness, see
-`.claude/notes/chantiers/luna_migration.md`)*
+Run: `python3 devtools/cyclecount/bench.py` — the suite was re-homed to
+`devtools/cyclecount/` after the old `opensnes-emu` harness was removed, and
+runs in CI on every push as a cycle-count regression gate against the
+committed baseline. The comparative PVSnesLib numbers below are frozen at
+the 2026-05-13 measurement (re-running them needs a tcc816 toolchain).*
 
 ## Summary
 
@@ -24,7 +26,7 @@ tcc816 + 816-opt peephole optimizer on our benchmark suite of 34 isolated functi
 
 ## Methodology
 
-Each function in `tools/opensnes-emu/test/fixtures/benchmark/bench_functions.c` isolates one code generation
+Each function in `devtools/cyclecount/bench_functions.c` isolates one code generation
 pattern (arithmetic, shifts, loops, struct access, function calls, etc.). Both
 compilers process the same source file:
 
@@ -229,7 +231,7 @@ Why a trailer rather than a PR label or special comment marker:
 ### What the gate does NOT cover
 
 The benchmark surface is narrow: 34 isolated functions in
-`tools/opensnes-emu/test/fixtures/benchmark/bench_functions.c`. A PR can
+`devtools/cyclecount/bench_functions.c`. A PR can
 regress on real-world code without regressing on the benchmark, and vice
 versa. The gate is one input among several when evaluating
 compiler-touching changes — the visual-regression suite, runtime tests,

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -117,7 +117,8 @@ GENERATE_XML           = NO
 # Use custom CSS
 HTML_EXTRA_STYLESHEET  = doxygen-awesome-css/doxygen-awesome.css \
                          doxygen-awesome-css/doxygen-awesome-sidebar-only.css \
-                         doxygen-awesome-css/doxygen-awesome-sidebar-only-darkmode-toggle.css
+                         doxygen-awesome-css/doxygen-awesome-sidebar-only-darkmode-toggle.css \
+                         opensnes-theme.css
 
 # JavaScript for dark mode toggle
 HTML_EXTRA_FILES       = doxygen-awesome-css/doxygen-awesome-darkmode-toggle.js \

--- a/docs/header.html
+++ b/docs/header.html
@@ -21,6 +21,9 @@ $treeview
 $search
 $mathjax
 $darkmode
+<!-- tabs.css is part of the default doxygen header; dropping it left the
+     dynamic menu's toggle rendering as a raw checkbox + label text. -->
+<link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>
 <link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
 $extrastylesheet
 <!-- doxygen-awesome-css companion scripts. HTML_EXTRA_FILES copies these to
@@ -43,3 +46,16 @@ DoxygenAwesomeFragmentCopyButton.init()
 DoxygenAwesomeParagraphLink.init()
 /* @license-end */
 </script>
+<!-- Standard Doxygen title area, dropped when this custom header was first
+     written — doxygen-awesome's sidebar-only layout relocates it to the top
+     of the fixed sidebar, so without it the site shows no logo or project
+     name anywhere. Placeholders are substituted by Doxygen from Doxyfile. -->
+<div id="titlearea">
+<table cellspacing="0" cellpadding="0"><tbody><tr>
+ <td id="projectlogo"><a href="$relpath^index.html"><img alt="OpenSNES" src="$relpath^logo_64x64.png"/></a></td>
+ <td id="projectalign">
+  <div id="projectname">$projectname</div>
+  <div id="projectbrief">$projectbrief</div>
+ </td>
+</tr></tbody></table>
+</div>

--- a/docs/opensnes-theme.css
+++ b/docs/opensnes-theme.css
@@ -1,0 +1,106 @@
+/**
+ * OpenSNES brand theme — layered over doxygen-awesome-css.
+ *
+ * Palette extracted from assets/logo.svg (the single source of truth):
+ *   deep navy  #12121e   (logo background → dark-mode page)
+ *   SNES violet #7161de / #8a7aee  (cartridge body → primary)
+ *   terminal green #0bdb52         (the "OS>" pixels → dark-mode links,
+ *                                   light-mode non-text highlights only:
+ *                                   green on white is ~1.9:1, never text)
+ *   magenta    #e71861 · yellow #f6d714  (accent bar → header signature)
+ *   label navy #1a2a3a / #2b4555   (cartridge label → dark surfaces)
+ *
+ * All text/background pairs verified WCAG AA (≥4.5:1):
+ *   #7161de on #ffffff 4.70 · #4a3f9e on #ffffff 8.41 · #0bdb52 on
+ *   #12121e 9.96 · #8a7aee on #12121e 5.39 · #d5d5e0 on #12121e 12.75
+ *
+ * Light mode stays paper-clean (violet primary, restrained accents);
+ * dark mode is the full brand moment (logo navy + terminal green).
+ */
+
+html {
+    /* Primary: SNES cartridge violet */
+    --primary-color: #7161de;
+    --primary-dark-color: #4a3f9e;
+    --primary-light-color: #8a7aee;
+
+    /* Terminal-green reserved for non-text highlights in light mode */
+    --opensnes-green: #0bdb52;
+    --opensnes-magenta: #e71861;
+    --opensnes-yellow: #f6d714;
+
+    --fragment-linenumber-color: #8a7aee;
+}
+
+html.dark-mode {
+    color-scheme: dark;
+
+    /* The logo background becomes the page */
+    --page-background-color: #12121e;
+    --side-nav-background: #0e0e18;
+    --code-background: #1a2a3a;          /* cartridge label navy */
+    --fragment-background: #16162399;
+
+    /* Terminal green carries the links, violet the secondary accents */
+    --primary-color: #0bdb52;
+    --primary-dark-color: #8a7aee;
+    --primary-light-color: #0bdb52;
+
+    --page-foreground-color: #d5d5e0;
+    --page-secondary-foreground-color: #a9b399;   /* label-text olive */
+
+    --separator-color: #2a2a4a;                    /* connector shell */
+    --border-radius-large: 8px;
+
+    --fragment-linenumber-color: #6a6a8a;          /* connector pins */
+
+    --searchbar-background: #1a2a3a;
+    --header-background: #12121e;
+    --header-foreground: #d5d5e0;
+}
+
+/*
+ * Signature: the logo's tri-color accent bar (magenta / yellow / green)
+ * as a fixed 3px line across the top of every page — the one place the
+ * full accent palette appears, mirroring the bar under the "OPENSNES"
+ * label text in the logo. body::before because this layout (custom
+ * header + sidebar-only) emits no #top element to attach to.
+ */
+body::before {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    z-index: 400;
+    background: linear-gradient(
+        to right,
+        var(--opensnes-magenta) 0 38%,
+        var(--opensnes-yellow) 38% 62%,
+        var(--opensnes-green) 62% 100%
+    );
+}
+
+/* Sidebar title area (restored in header.html): compact brand lockup */
+#titlearea {
+    border-bottom: 1px solid var(--separator-color);
+}
+#projectbrief {
+    font-size: 11px;
+    color: var(--page-secondary-foreground-color);
+}
+
+/* Project name in the header: monospace nod to the pixel-art wordmark */
+#projectname {
+    font-family: 'JetBrains Mono', 'Courier New', ui-monospace, monospace;
+    letter-spacing: 0.06em;
+}
+
+/* Active sidebar item gets the terminal-green marker (non-text highlight,
+ * so it is safe in both modes) */
+#side-nav .item.selected > .label a,
+#nav-tree .item.selected > .label a {
+    border-left: 3px solid var(--opensnes-green);
+    padding-left: 6px;
+}

--- a/lib/include/snes.h
+++ b/lib/include/snes.h
@@ -56,10 +56,10 @@
 #define OPENSNES_VERSION_MINOR 27
 
 /** @brief OpenSNES patch version */
-#define OPENSNES_VERSION_PATCH 0
+#define OPENSNES_VERSION_PATCH 1
 
 /** @brief OpenSNES version string */
-#define OPENSNES_VERSION_STRING "0.27.0"
+#define OPENSNES_VERSION_STRING "0.27.1"
 
 /*============================================================================
  * Core Headers

--- a/tools/luna-test/README.md
+++ b/tools/luna-test/README.md
@@ -1,19 +1,19 @@
-# luna-test — Luna-backed test harness (migration, Phase 1)
+# luna-test — Luna-backed test harness
 
-Prototype replacement for `tools/opensnes-emu` (snes9x-WASM) + Mesen2, built on
+The project's test harness, built on
 [luna](https://github.com/k0b3n4irb/luna) — a cycle-accurate Rust SNES emulator
 that runs headless, detects/executes SA-1 + Super FX (GSU) + DSP-1, and exposes
 the full machine state via CLI / API / MCP.
 
-See the full plan: `/tmp/luna_migration_report_2026-06-20.md` and
-`.claude/notes/chantiers/luna_migration.md`.
+Migration history: `.claude/notes/chantiers/luna_migration.md`.
 
 ## Status
 
-**Active backend.** luna is now the **sole** test backend: the snes9x-WASM +
-Mesen2 harness (`tools/opensnes-emu`) was removed. `make tests` runs corpus
-liveness coverage + full-corpus visual regression (56 examples) + functional
-probes. Compile-time cc65816 checks live in `devtools/compiler-tests/`.
+**Sole test backend** (the snes9x-WASM + Mesen2 harness `tools/opensnes-emu`
+was removed). `make tests` runs corpus liveness coverage + full-corpus visual
+regression + functional probes (scripted input → WRAM asserts), and CI adds
+the WRAM-state stream regression (`wram_regress.py`, cross-arch exclusions).
+Compile-time cc65816 checks live in `devtools/compiler-tests/`.
 
 ## Requirements
 
@@ -36,17 +36,18 @@ python3 tools/luna-test/luna_runner.py --only sa1  # one label substring
 
 ## How it works
 
-For each example the runner calls `luna run -n <steps> --screenshot <png>` and
-keys the regression on the **SHA-256 of the rendered PNG**. luna's headless
-framebuffer is byte-deterministic run-to-run (verified in the Phase 0 spike), so
-the hash is a stable, drift-free gate; the PNG is kept next to it for human
-diffing (decision #1: hash gate **+** PNG debug). The runner computes the visual
-verdict itself; luna v0.3.0 also provides `--assert BANK:OFFSET=HEX` (+ `-aram`/
-`-vram`) for direct WRAM assertions, and `--print-fbhash` for a cross-arch-stable
-framebuffer key (see the cross-arch note below).
+For each example the runner calls `luna run -n <steps> --print-fbhash
+--screenshot <png>` and keys the regression on **luna's `fbhash`** — a hash of
+the pre-PNG pixels, byte-deterministic run-to-run and cross-arch-stable (see
+the note below); the PNG is kept next to it for human diffing (hash gate **+**
+PNG debug). luna also provides `--assert BANK:OFFSET=HEX` (+ `-aram`/`-vram`)
+for direct WRAM assertions, used by the probes.
 
 Baselines live in `baselines/`: `<label>.png` + a single `baselines.json`
-manifest (`sha256`, `steps`, `rom_sha256`, `luna_version`).
+manifest (`fbhash`, `steps`, `rom_sha256`, `luna_version`). Self-animating
+examples opt into MULTIPLE capture points via `manifest.toml`
+`steps = [a, b]` — `fbhash`/`steps` become lists, extra PNGs are
+`<label>@<steps>.png`, and a partial mismatch is reported as "timing drift?".
 
 ## Cross-arch baseline key
 
@@ -58,13 +59,14 @@ PNG is kept only for human diffing, not hashed. If a future luna release ever
 breaks fbhash cross-arch stability, that's a luna bug — regenerate baselines with
 `luna_runner.py --update` on the CI arch as a stopgap and report it.
 
-## Not yet migrated (tracked in the chantier note)
+## Migration complete
 
-Runtime/WRAM probes (`luna state --peek`), lag detection (`state.stats`), input
-sequences (`--input`), `luna bench` corpus run, the MCP swap (`luna mcp`), the
-full 56-example manifest, and the CI rewrite. (Mouse/Super Scope were boot+visual
-only until luna v1.1.0 added scripted peripheral input — now covered by
-`probes/mouse.py` + `probes/superscope.py`, see below.)
+Everything the chantier scoped has landed: runtime/WRAM probes (`probes/`,
+incl. mouse + Super Scope via luna v1.1.0's scripted peripheral input), the
+WRAM-stream regression (`wram_regress.py`, CI-gated with cross-arch
+exclusions), input sequences (`--input`), the full-corpus manifest, and the
+CI rewrite (both Linux arches). For interactive debugging, `luna mcp` /
+luna's GUI are available alongside Mesen2.
 
 ## Hardening tests (luna v1.1.0 capabilities)
 

--- a/tools/luna-test/luna_runner.py
+++ b/tools/luna-test/luna_runner.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
-"""Luna-backed visual-regression runner (Phase 1 prototype).
+"""Luna-backed visual-regression runner.
 
-Part of the migration off snes9x-WASM + Mesen2 onto luna
-(see /tmp/luna_migration_report_2026-06-20.md and
+Successor to the snes9x-WASM + Mesen2 harness (migration history:
 .claude/notes/chantiers/luna_migration.md).
 
 What it does


### PR DESCRIPTION
Documentation-site branding and repository housekeeping. See the CHANGELOG entry.

## Highlights
- **feat(docs)**: OpenSNES brand theme for the docs site — logo palette (SNES-violet light mode, logo-navy + terminal-green dark mode), tri-color signature bar, logo + wordmark on every page, all pairs WCAG AA
- **fix(docs)**: the deployed site rendered a raw menu-toggle checkbox on every page and showed no project name/logo anywhere (dropped titlearea + tabs.css in the custom header — both restored)
- docs housekeeping: stale migration-era claims retired; wla-dx submodule build noise silenced (`ignore = dirty`)

Pre-release: full rebuild + `make tests` ALL CHECKS PASSED (56/56 visual, WRAM 54/54, probes 14/14), `make lint` + `lint-docs` green. Merging deploys the themed docs site via deploy_docs.