### PR TITLE
release: v0.35.0

### DIFF
--- a/.claude/rules/luna_tooling.md
+++ b/.claude/rules/luna_tooling.md
@@ -1,0 +1,69 @@
+# Luna-First: internal scripts are transitory (Auto-loaded)
+
+CRITICAL, load-bearing convention (owner decision, 2026-08-05):
+
+**Everything goes through luna. luna is the single validation/emulation backend
+— the one source of truth for running, inspecting, and judging ROMs.**
+
+Internal scripts (Python or any language) that add a *capability luna does not
+yet expose* are **TRANSITORY PROTOTYPES**, never permanent tools. The ideal
+steady state is **zero permanent internal validation code**: every need is
+covered by luna itself. A prototype exists only to discover and *prove the exact
+capability* luna should own, so the eventual luna feature is specified by a
+working reference, not a hunch.
+
+## The mandatory lifecycle for a missing capability
+
+1. **PROTOTYPE** — write the smallest internal script that proves the capability
+   and pins its exact shape (what input, what output, what assertion). Use it for
+   real work in the meantime. Keep it under `tools/luna-test/`.
+2. **VALIDATE with the owner** — show that the prototype does what's needed; get
+   explicit sign-off. Do **not** file a luna issue on a guess — the owner
+   validates internally what's missing first.
+3. **FILE the luna issue** — only when sure. Describe precisely what luna should
+   expose; the prototype **is** the spec (paste its I/O contract). This is the
+   "challenge luna" step.
+4. **luna SHIPS it** (exactly as agreed) → **validate together** that the shipped
+   capability reproduces the prototype's output.
+5. **DELETE the prototype** — rewire every caller to luna and remove the internal
+   code. The capability now lives in luna. Leaving the script behind creates a
+   second, drifting source of truth — the exact thing this rule forbids.
+
+## Transitory vs. not
+
+- **Transitory (must eventually disappear):** any script that *reimplements a
+  capability luna should own* — decoding, analysis, capture, measurement.
+  Example: audio FFT/pitch/envelope analysis; a bespoke ROM disassembly; a
+  hand-rolled state differ.
+- **Not transitory (the thin orchestration layer):** the harness that merely
+  *drives* luna and asserts on its outputs — `luna_runner.py`, `wram_regress.py`,
+  `budget.py`, `probes/*`. These call luna; they do not reimplement it. They are
+  the pragmatic exception, and still shrink as luna exposes more. When in doubt:
+  *am I asking luna and checking its answer (keep), or computing the answer luna
+  should give (transitory)?*
+
+## Current transitory prototypes (keep this list live)
+
+**None right now** — the ideal steady state. When a missing capability forces a
+prototype, add a row here (script path · the luna capability it proves · status)
+and follow the lifecycle above; when luna ships the capability and it is
+validated, delete the script and remove the row.
+
+A prior audio-output-analysis prototype (`audio_analyze.py`) was dropped rather
+than promoted: it proved unreliable for melody/tempo verification, so it is not
+a sound basis for a luna capability request. Any future audio-analysis need
+starts a fresh prototype held to the validation bar above before any luna issue.
+
+## Why this exists
+
+A permanent internal tool is a second source of truth: it drifts from luna, is
+invisible to contributors who only have luna, and duplicates work luna should
+own. Prototypes are cheap and *hyper-useful for the everyday* — but they are
+scaffolding. The finished building is luna.
+
+## Cross-references
+
+- `.claude/rules/testing.md` — luna is already the test backend; this rule adds
+  the transitory-tooling discipline on top.
+- The owner runs luna engineering: validated capability requests become luna
+  issues (`gh issue create --repo k0b3n4irb/luna`), tracked to deletion here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to OpenSNES are documented in this file.
 
+## [0.35.0] — 2026-08-07
+
+A documentation-and-tooling release. The developer-experience push from 0.34.0
+continues: a static, build-time asset-budget report to pair with the runtime
+one, a complete **Tools** documentation section so newcomers discover and learn
+every asset converter from the docs, and two more game-craft guides.
+
+### Added
+- feat(devtools,build): **static VRAM/CGRAM asset-budget report** — a new
+  `make asset-budget` command that weighs the converted graphics on disk (tiles
+  and maps → VRAM, palettes → CGRAM) against the 64 KB / 256-colour limits, the
+  build-time twin of the runtime `make budget`. It also prints a compact
+  `[ASSETS]` instrument line at every example link (silent for asset-less
+  builds, `SKIP_ASSET_BUDGET=1` to disable). Report-only, never a gate — an
+  inventory upper bound, since streaming and palette swaps legitimately exceed
+  the limits.
+
+### Documentation
+- docs(tools): a **complete Tools documentation section** (`docs/tools/`) — a
+  toolbox landing page plus a presentation-and-tutorial page for each converter
+  (gfx4snes, tmx2snes, img2snes, font2snes, wav2brr, smconv), wired into the
+  doc site and nav. Facts verified against each tool's README and live `--help`.
+- docs(craft): two **craft companions** — *camera* (deadzone, look-ahead,
+  platform snapping, room-locking, all derived from one camera value) and
+  *game-feel* (screen shake, hit flash via color math, hitstop, fades, palette
+  cycling — the SNES-specific tricks).
+- docs(craft): a **cost-by-mode table** in the planning guide — per-mode layer
+  layout, bytes/tile by colour depth, and the VRAM trade for each background
+  mode.
+- docs(rules): the **luna-first** transitory-tooling convention (internal
+  contributor rule) — everything validates through luna; internal scripts are
+  transitory prototypes to be retired once luna owns the capability.
+
 ## [0.34.0] — 2026-08-04
 
 The DSP-1 & developer-ecosystem release. OpenSNES gains first-class **DSP-1**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ The `.claude/rules/` directory contains mandatory rules automatically loaded by 
 - `doc_consistency.md` — Anchored doc/code claims (version macros, ROADMAP status, examples count). Run `make lint-docs` before any release commit; must consult before editing version strings or example counts.
 - `bank0_budget.md` — Bank $00 ROM hard-fail ratchet (`BANK0_FAIL_THRESHOLD`); must consult before adding const data or tuning the threshold.
 - `abi_lint.md` — ASM ABI lint policy and the `; lint-asm-abi: skip-file` marker; must consult before adding a new ASM file or retrofitting for an ABI change.
+- `luna_tooling.md` — Luna-First: everything goes through luna; internal capability scripts are transitory prototypes (prototype → owner-validate → luna issue → luna ships → delete). Must consult before adding any internal validation/analysis script.
 
 ## Strategic Planning
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ else
 endif
 
 .DEFAULT_GOAL := all
-.PHONY: all clean clean-examples install compiler tools lib examples cli tests test-compiler test-tools test-wram bench submodules verify-toolchain lint-commits lint-docs lint-asm-abi lint-vram lint docs help release clean-release
+.PHONY: all clean clean-examples install compiler tools lib examples cli tests test-compiler test-tools test-wram bench budget asset-budget submodules verify-toolchain lint-commits lint-docs lint-asm-abi lint-vram lint docs help release clean-release
 
 #------------------------------------------------------------------------------
 # Main targets
@@ -210,6 +210,13 @@ test-wram:
 # with docs/craft/planning.md. `make budget ARGS="--only mode2"` to focus.
 budget:
 	@python3 tools/luna-test/budget.py $(ARGS)
+
+# Static asset-budget report (VRAM/CGRAM weight of the converted graphics on
+# disk, no ROM run). The build-time twin of `make budget`: that measures the
+# runtime footprint via luna, this weighs the assets you built. Report-only —
+# an inventory upper bound, not a gate. `make asset-budget ARGS="--only mode1"`.
+asset-budget:
+	@python3 devtools/asset_budget.py $(ARGS)
 
 # Compiler cycle-count regression guard (static estimate vs committed baseline).
 bench:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ and **what is next**.
 
 ---
 
-## Current Status: post-v0.34.0
+## Current Status: post-v0.35.0
 
 A modern, well-tested SNES SDK ready for serious hobby development, game jams,
 and educational use, building toward commercial-grade maturity. The compiler
@@ -296,6 +296,6 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for guidelines, branch policy
 (`main` = stable / `develop` = active), and PR rules. Build instructions
 live in [`README.md`](README.md).
 
-*Last updated: 2026-08-04. Anchored claims (version, examples count, framework
+*Last updated: 2026-08-07. Anchored claims (version, examples count, framework
 opt-in list) verified by `make lint-docs` — see `devtools/check_doc_drift.py`
 and `.claude/rules/doc_consistency.md`.*

--- a/devtools/asset_budget.py
+++ b/devtools/asset_budget.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Static PPU asset-budget report — VRAM / CGRAM weight of converted graphics.
+
+This is the *build-time, static* twin of `tools/luna-test/budget.py`. Where that
+one asks luna how much VRAM/CGRAM a running scene actually fills (a runtime
+footprint, a lower bound), this one weighs the **converted asset files on disk**
+before the ROM ever runs — the "budget before you draw" worksheet from
+`docs/craft/craft_planning` turned into a number, with no emulator involved.
+
+It reads only the gfx4snes / tmx2snes pipeline outputs:
+
+    .pic / .pc7   tile data      -> VRAM (bytes)
+    .map / .mp7   tilemap data   -> VRAM (bytes)
+    .pal          palette        -> CGRAM (2 bytes per colour)
+
+and totals them per example against the hard limits:
+
+    VRAM 65536 bytes   ·   CGRAM 256 colours
+
+What this is NOT: it does not know the game's *runtime* VRAM layout. It is an
+inventory — the total weight of an example's converted graphics — and thus an
+*upper bound* on what those assets could occupy if loaded at once. A streaming
+game legitimately ships more asset bytes than fit in VRAM (it loads a window at
+a time), so a total over 64 KB is a flag to think, not a failure. For "what is
+actually resident in a scene," run `make budget` (the luna runtime measure).
+The two are complementary: this bounds the assets you built; that measures the
+scene you loaded.
+
+Because it over-counts (streaming, non-simultaneous loads, LZ77-compressed .pic
+that expand in VRAM), it is a **report with a soft warning**, never a build
+gate — unlike the linker-side bank-$00 / RAM ratchets in symmap.py.
+
+Usage:
+  python3 devtools/asset_budget.py                  # whole corpus, sorted heaviest first
+  python3 devtools/asset_budget.py --only mode1     # examples whose path contains "mode1"
+  python3 devtools/asset_budget.py --warn 80        # flag examples >= 80% of any limit
+  python3 devtools/asset_budget.py examples/games/rpg
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+VRAM_LIMIT = 65536      # bytes
+CGRAM_LIMIT = 256       # colours
+
+TILE_EXT = {".pic", ".pc7"}
+MAP_EXT = {".map", ".mp7"}
+PAL_EXT = {".pal"}
+
+
+class Budget:
+    """VRAM/CGRAM weight of one example's converted assets."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.tiles = 0      # bytes
+        self.maps = 0       # bytes
+        self.pal_bytes = 0  # bytes (2 per colour)
+        self.files = 0
+
+    def add(self, path: Path) -> None:
+        ext = path.suffix.lower()
+        size = path.stat().st_size
+        if ext in TILE_EXT:
+            self.tiles += size
+        elif ext in MAP_EXT:
+            self.maps += size
+        elif ext in PAL_EXT:
+            self.pal_bytes += size
+        else:
+            return
+        self.files += 1
+
+    @property
+    def vram(self) -> int:
+        return self.tiles + self.maps
+
+    @property
+    def colours(self) -> int:
+        return self.pal_bytes // 2
+
+    @property
+    def worst_pct(self) -> float:
+        return max(100.0 * self.vram / VRAM_LIMIT,
+                   100.0 * self.colours / CGRAM_LIMIT)
+
+
+def scan_example(example_dir: Path) -> Budget:
+    """Total every converted asset found under an example directory."""
+    b = Budget(str(example_dir))
+    for path in example_dir.rglob("*"):
+        if path.is_file() and path.suffix.lower() in (TILE_EXT | MAP_EXT | PAL_EXT):
+            b.add(path)
+    return b
+
+
+def find_examples(root: Path) -> list[Path]:
+    """Every directory holding a main.c (one example each)."""
+    return sorted({p.parent for p in root.rglob("main.c")})
+
+
+def kb(n: int) -> str:
+    return f"{n / 1024:.1f}K"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Static PPU asset-budget report")
+    ap.add_argument("paths", nargs="*", type=Path,
+                    help="example dirs to scan (default: examples/ corpus)")
+    ap.add_argument("--only", metavar="SUBSTR",
+                    help="only examples whose path contains SUBSTR")
+    ap.add_argument("--warn", type=float, default=80.0, metavar="PCT",
+                    help="flag examples at >= PCT%% of any limit (default 80)")
+    ap.add_argument("--oneline", action="store_true",
+                    help="compact one-line-per-example output for post-build use "
+                         "(silent when an example has no converted assets)")
+    args = ap.parse_args()
+
+    repo = Path(__file__).resolve().parent.parent
+    if args.paths:
+        example_dirs = [p if p.is_absolute() else repo / p for p in args.paths]
+    else:
+        example_dirs = find_examples(repo / "examples")
+    if args.only:
+        example_dirs = [d for d in example_dirs if args.only in str(d)]
+
+    budgets = []
+    for d in example_dirs:
+        b = scan_example(d)
+        b.name = str(d.relative_to(repo)) if d.is_relative_to(repo) else str(d)
+        b.name = b.name.replace("examples/", "")
+        if b.files:
+            budgets.append(b)
+
+    # Compact per-build line (post-link instrument, like the bank-$00/RAM lines).
+    # Silent for asset-less examples so audio/text builds add no noise, and no
+    # warning marker: an inventory over 100% is legitimate (streaming, per-scene
+    # or per-scanline palette swaps), so a per-build alarm would cry wolf.
+    if args.oneline:
+        for b in budgets:
+            vpct = 100.0 * b.vram / VRAM_LIMIT
+            cpct = 100.0 * b.colours / CGRAM_LIMIT
+            print(f"[ASSETS] VRAM {kb(b.vram)}/64K ({vpct:.0f}%) · "
+                  f"CGRAM {b.colours}/256 ({cpct:.0f}%)")
+        return 0
+
+    if not budgets:
+        print("no converted assets found "
+              "(build the examples first: `make examples`)")
+        return 0
+
+    budgets.sort(key=lambda b: b.vram, reverse=True)
+
+    print(f"{'example':<34} {'VRAM':>12} {'CGRAM':>11}   breakdown")
+    print(f"{'':<34} {'/64K':>12} {'/256':>11}")
+    print("-" * 90)
+    flagged = 0
+    for b in budgets:
+        vpct = 100.0 * b.vram / VRAM_LIMIT
+        cpct = 100.0 * b.colours / CGRAM_LIMIT
+        mark = " !" if b.worst_pct >= args.warn else ""
+        vram_col = f"{kb(b.vram):>6} {vpct:4.0f}%"
+        cgram_col = f"{b.colours:>4} {cpct:4.0f}%"
+        detail = f"tiles {kb(b.tiles)}, maps {kb(b.maps)}, pal {b.colours}c"
+        print(f"{b.name:<34} {vram_col:>12} {cgram_col:>11}   {detail}{mark}")
+        if b.worst_pct >= args.warn:
+            flagged += 1
+
+    print("-" * 90)
+    print(f"{len(budgets)} examples with assets · "
+          f"VRAM limit 64K · CGRAM limit 256 colours")
+    if flagged:
+        print(f"! {flagged} at >= {args.warn:.0f}% of a limit — an inventory upper "
+              f"bound; see `make budget` for the runtime footprint.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/test_asset_budget.py
+++ b/devtools/test_asset_budget.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Tests for devtools/asset_budget.py — the static PPU asset-budget report.
+
+Run: python3 devtools/test_asset_budget.py
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from asset_budget import Budget, scan_example, VRAM_LIMIT, CGRAM_LIMIT
+
+
+def _write(d: Path, name: str, size: int) -> None:
+    (d / name).write_bytes(b"\x00" * size)
+
+
+def test_categorisation_and_totals():
+    """tiles+maps -> VRAM bytes; palette bytes -> colours (2 bytes each)."""
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        _write(d, "gfx.pic", 2592)   # tiles
+        _write(d, "gfx.map", 2048)   # map
+        _write(d, "gfx.pal", 32)     # palette -> 16 colours
+        b = scan_example(d)
+        assert b.tiles == 2592, b.tiles
+        assert b.maps == 2048, b.maps
+        assert b.vram == 2592 + 2048, b.vram
+        assert b.colours == 16, b.colours
+        assert b.files == 3, b.files
+
+
+def test_mode7_and_nested_res_dir():
+    """.pc7/.mp7 count as tiles/maps; rglob reaches a res/ subdir."""
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        res = d / "res"
+        res.mkdir()
+        _write(res, "world.pc7", 4096)   # mode7 tiles
+        _write(res, "world.mp7", 16384)  # mode7 map
+        _write(res, "world.pal", 512)    # 256 colours
+        b = scan_example(d)
+        assert b.tiles == 4096, b.tiles
+        assert b.maps == 16384, b.maps
+        assert b.vram == 4096 + 16384, b.vram
+        assert b.colours == 256, b.colours
+
+
+def test_ignores_unrelated_files():
+    """PNG sources, .c, .o etc. must not count toward the budget."""
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        _write(d, "gfx.png", 5000)
+        _write(d, "main.c", 800)
+        _write(d, "gfx.pic", 1024)
+        b = scan_example(d)
+        assert b.vram == 1024, b.vram
+        assert b.files == 1, b.files
+
+
+def test_worst_pct_over_limit():
+    """worst_pct exceeds 100 when an inventory overflows a limit (streaming/swaps)."""
+    b = Budget("x")
+    b.tiles = VRAM_LIMIT + 1
+    assert b.worst_pct > 100.0
+    b2 = Budget("y")
+    b2.pal_bytes = (CGRAM_LIMIT + 1) * 2   # more colours than fit at once
+    assert b2.worst_pct > 100.0
+
+
+def test_empty_example_has_no_files():
+    with tempfile.TemporaryDirectory() as td:
+        b = scan_example(Path(td))
+        assert b.files == 0
+        assert b.vram == 0
+        assert b.colours == 0
+
+
+def test_oneline_prints_for_assets_and_is_silent_when_empty():
+    """--oneline (used post-build): one compact line for assets, nothing when none."""
+    import subprocess
+    script = str(Path(__file__).resolve().parent / "asset_budget.py")
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        _write(d, "g.pic", 1024)
+        _write(d, "g.pal", 32)
+        out = subprocess.run([sys.executable, script, "--oneline", td],
+                             capture_output=True, text=True).stdout
+        assert "[ASSETS]" in out, out
+        assert out.strip().count("\n") == 0, "expected exactly one line"
+    with tempfile.TemporaryDirectory() as td2:
+        out2 = subprocess.run([sys.executable, script, "--oneline", td2],
+                              capture_output=True, text=True).stdout
+        assert out2.strip() == "", repr(out2)
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print(f"ok  {fn.__name__}")
+    print(f"\n{len(fns)} tests passed")

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -27,6 +27,7 @@ INPUT                  = mainpage.md \
                          ../lib/include/snes.h \
                          tutorials/ \
                          craft/ \
+                         tools/ \
                          GETTING_STARTED.md \
                          LEARNING_PATH.md \
                          EXAMPLES_BY_CATEGORY.md \

--- a/docs/craft/README.md
+++ b/docs/craft/README.md
@@ -34,8 +34,12 @@ Two ideas run through every guide here:
 - @subpage craft_tiles_to_levels — **From tiles to levels.** Think in metatiles,
   attach collision and meaning to tiles, stream a level bigger than VRAM, and
   author it in Tiled instead of by hand.
-
-*(More on the way: per-technique craft companions — camera, game-feel.)*
+- @subpage craft_camera — **Following the player: the camera.** Deadzones,
+  look-ahead, platform snapping, room-locking — all derived from one camera
+  value that feeds every layer's scroll.
+- @subpage craft_game_feel — **Game feel: juice on real hardware.** Screen
+  shake, hit flash, hitstop, fades, palette cycling — the SNES-specific tricks
+  that make an action feel good, each a few cheap frames.
 
 ## Go deeper — the curated shelf
 

--- a/docs/craft/camera.md
+++ b/docs/craft/camera.md
@@ -1,0 +1,109 @@
+# Following the player: the camera {#craft_camera}
+
+@ref craft_backgrounds composed the *layers*; this guide moves the *window* over
+them. A camera is how the visible 256×224 screen tracks the player through a
+world larger than itself — and on the SNES there is no camera object to
+configure, only scroll registers you write every frame. The universal theory of
+good cameras is written down beautifully already (see the Go-deeper box); this
+guide is how to land it on this hardware, with this SDK. For the registers
+themselves, see @ref snes_graphics_guide.
+
+## The camera *is* your scroll values
+
+There is no viewport primitive. Moving the camera right means increasing BG1's
+horizontal scroll, which you push with `bgSetScroll` and the PPU latches at
+VBlank. Everything below is just *what number to feed it each frame*.
+
+Two consequences fall straight out of the earlier guides:
+
+- **Parallax is the camera, scaled.** Your midground and sky are the same camera
+  position multiplied by a fraction — see @ref craft_backgrounds. One camera
+  drives every layer; you never track them separately.
+- **It is a PPU write, so it happens in VBlank.** Compute the new camera during
+  active display; the scroll latch lands at VBlank (@ref craft_frame_budget).
+  The SDK's NMI scroll-sync does the latching for you.
+
+## Don't glue the camera to the player — deadzone it
+
+The beginner camera sets scroll to the player's position. It works, and it is
+subtly awful: every idle bob and half-pixel shoves the whole screen, and the
+eye never rests. The fix is a **deadzone** (camera window): a box in the middle
+of the screen the player moves *inside* freely; the camera only scrolls when
+they reach its edge, and then only enough to keep them in the box.
+
+```
+   screen
+ ┌───────────────┐     player roams the inner box for free;
+ │   ┌───────┐   │     the camera holds still. Push the edge
+ │   │  ▶    │   │     and the camera scrolls just enough to
+ │   └───────┘   │     keep the box around the player.
+ └───────────────┘
+```
+
+A wide horizontal deadzone with almost no vertical one is the platformer
+default: free side-to-side wander, tight vertical tracking.
+
+## Lead the action — look-ahead
+
+Bias the camera *ahead* of the player in the direction they face or move, so
+they see what they are running into rather than sitting dead-centre. The trick
+is to move the target smoothly — ease the camera toward the offset over several
+frames rather than snapping — or a facing-flip turns into a lurch. This is the
+one place a little per-frame interpolation earns its cost.
+
+## Vertical wants different rules
+
+Vertical camera motion is where cheap cameras get sickening: follow the
+player's Y exactly and every jump heaves the screen. Common fixes, in order of
+reach:
+
+- **Snap on ground only.** Track Y while grounded; during a jump, hold the
+  camera and let the player rise and fall within the frame.
+- **Platform bands.** Move the vertical camera in discrete steps when the player
+  settles on a new platform, not continuously.
+
+@ref examples_games_likemario is a full platformer to read for how camera,
+scroll and streaming fit together.
+
+## Clamp to the world — room-locking
+
+A camera that follows past the level's edge reveals the void beyond your
+tilemap. **Clamp the scroll** to the world: never below 0, never past
+`level_pixels − screen_pixels` on each axis. This is also where the camera meets
+the streaming map from @ref craft_tiles_to_levels — the map engine ties the
+camera's position to which column it streams next, and the same clamp that stops
+the view at the edge stops you streaming past the last column.
+
+| Follow style | Feeds | See |
+|--------------|-------|-----|
+| Whole screen scrolls with the player | `bgSetScroll` per layer | @ref examples_scrolling_mixed_scroll |
+| Layers scroll at different rates | one camera × per-layer fraction | @ref examples_scrolling_parallax_scroll |
+| World wider than VRAM, streamed | camera drives column streaming | @ref examples_maps_map_scroll, @ref examples_scrolling_continuous_scroll |
+| Free-scrolling 2D field | clamp both axes to bounds | @ref examples_maps_dynamic_map |
+
+## Write it at the right moment
+
+Camera scroll is a PPU register write, so it obeys the @ref craft_frame_budget —
+do the follow math during active display, and let the scroll latch at VBlank. Latch
+mid-frame by hand and you tear the image — a layer scrolled on line 100 shows
+the seam. Let the NMI scroll-sync apply it and the whole screen moves as one.
+
+> **Go deeper.** For the movement theory itself — deadzones, look-ahead,
+> platform snapping, room-locking, and a taxonomy of every camera in the
+> canon — read Itay Keren's
+> [Scroll Back](https://docs.google.com/document/d/1iNSQIyNpVGHeak6isbP6AHdHD50gs8MNXF1GCf08efg/pub).
+> Compose your layers in @ref craft_backgrounds; decide how the camera *follows*
+> here; feed both from one camera value.
+
+## The one rule
+
+Track one camera position; derive everything — every layer's scroll, every
+parallax fraction, the streaming boundary — from it. The player should feel the
+world move, never the camera work. A deadzone plus an edge clamp gets you most
+of the way there before you write a line of easing.
+
+> **Sources:**
+> [fullsnes](https://problemkaputt.de/fullsnes.htm) and the
+> [SNESdev Wiki](https://snes.nesdev.org/wiki) (BG scroll registers, VBlank
+> latch); the SDK's map engine (`lib/include/snes/map.h`) for camera-driven
+> streaming.

--- a/docs/craft/game-feel.md
+++ b/docs/craft/game-feel.md
@@ -1,0 +1,93 @@
+# Game feel: juice on real hardware {#craft_game_feel}
+
+"Game feel" is the layer of feedback that makes a jump feel springy and a hit
+feel like it landed — the same core mechanic reads as limp or delicious
+depending on it. The universal principles are covered definitively elsewhere
+(see Go-deeper); what nobody covers is *how to produce that juice on the SNES*,
+where you have no shader, no tween library, and a 4 KB VBlank budget. Almost
+every classic effect turns out to be a cheap trick on a PPU register. This guide
+is the SNES-specific toolbox; for the registers behind each, see
+@ref snes_graphics_guide.
+
+## Screen shake — nudge the scroll
+
+The highest impact-per-byte effect on the machine: on a big hit, add a small
+random offset to every background's scroll for a few frames and decay it to
+zero. It is just the camera from @ref craft_camera, perturbed — a couple of
+pixels, three or four frames, fading out. Costs nothing, sells everything. Shake
+the sprite layer too (offset your OAM Y) for an impact that rattles the whole
+screen, or shake only the backgrounds for a softer thud.
+
+## Hit flash — color math, not palette edits
+
+To flash a struck enemy white or tint the screen red on damage, do **not**
+rewrite palette entries every frame — that is a DMA you do not need. Use color
+math: the PPU adds or subtracts a fixed colour across a layer or the sprites in
+one register write. A one-frame white add on hit, a red subtract while the
+player is hurt, a blue wash underwater — all are @ref examples_color_shadow_tint
+and @ref examples_color_transparency territory, applied for a handful of frames.
+
+## Freeze the frame — hitstop
+
+The cheapest juice of all is *no* hardware: on a heavy hit, stop advancing the
+simulation for two to six frames. The image holds, the impact registers, then
+motion resumes. It is pure timing — a counter in your update loop — and it is
+what makes fighting games and action platformers feel like contact has weight.
+Pair it with a one-frame flash and a short shake and a plain collision becomes a
+*hit*.
+
+## Punctuate scene changes — fades and dissolves
+
+Cuts feel cheap; transitions feel authored. Two are nearly free on the SNES:
+
+- **Brightness fade** — ramp the screen master brightness (INIDISP) down to
+  black and back. The standard scene bookend. See @ref examples_transitions_fading.
+- **Mosaic dissolve** — grow the mosaic size to pixelate the screen away, then
+  shrink it back on the new scene. A distinctly SNES transition. See
+  @ref examples_transitions_mosaic.
+
+Both are a single register animated over a dozen frames, and both read as
+production value far above their cost.
+
+## Ambient life — palette cycling
+
+A static scene feels dead; a moving one feels alive. You do not need to animate
+tiles to get motion — **rotate a few palette entries** and water shimmers, lava
+churns, a portal pulses, with zero tile or DMA cost. It is the cheapest ongoing
+motion the hardware offers. See @ref examples_color_palette_cycle. The same
+lever gives you a low-health screen pulse or a power-up flash.
+
+## Squash and stretch without scaling
+
+SNES sprites do not scale outside Mode 7, so you fake elasticity the old way:
+**pre-draw a few frames** — a squashed sprite for the landing, a stretched one
+for the launch, held for a frame or two. It is the animation principle, not a
+hardware feature, and it is what separates a character that *thumps* onto the
+ground from one that merely stops. See @ref examples_sprites_animated_sprite for
+frame-driven animation. For rippling heat, water or a hit-wobble on a whole
+layer, per-scanline distortion via HDMA does what sprite scaling cannot — see
+@ref examples_hdma_hdma_wave.
+
+## Layer the little things
+
+Juice compounds. A coin pickup that is satisfying is rarely one effect — it is a
+flash, a small sound, a number that pops and rises, and maybe a one-frame
+freeze, all at once and all gone within a quarter-second. @ref examples_games_shmup_1942
+is worth reading for how modest effects stack into a game that feels responsive.
+
+> **Go deeper.** Watch Jonasson & Purho's
+> [Juice It or Lose It](https://www.gdcvault.com/play/1016487/Juice-It-or-Lose):
+> they take the same barebones game and layer juice onto it live. Every
+> technique they show maps to a cheap trick above.
+
+## The one rule
+
+Juice the verbs the player does most — jump, hit, collect, take damage — and
+make every effect *brief and decaying*: a few frames, fading to nothing. Feel
+comes from the sum of small, short responses to input, not from one big effect.
+Add them one at a time and stop when it feels right.
+
+> **Sources:**
+> [fullsnes](https://problemkaputt.de/fullsnes.htm) (color math, mosaic, INIDISP
+> brightness) and the [SNESdev Wiki](https://snes.nesdev.org/wiki); the SDK's
+> color-math and transition examples for the working code.

--- a/docs/craft/planning.md
+++ b/docs/craft/planning.md
@@ -77,12 +77,15 @@ examples_sprites_sprite_swarm measures exactly where this ceiling bites.
 > [SNES PPU article](https://fabiensanglard.net/snes_ppus_why/). It turns the
 > numbers above from arbitrary into obvious.
 
-> **Check it, don't guess it.** Once your ROM builds, run
-> `python3 tools/luna-test/budget.py your_game.sfc` for the live
-> VRAM/CGRAM/OAM footprint of a scene — this worksheet as a measured number.
-> `make budget` reports the same for every example in the SDK, so you can see
-> where a real game lands. (It measures non-zero content at the captured
-> frame, a lower bound — a gut-check, not a linker map.)
+> **Check it, don't guess it — twice.** Before the ROM even runs,
+> `make asset-budget` weighs your converted graphics — tiles, maps, palettes —
+> against the 64 KB / 256-colour limits: this worksheet, computed from the files
+> you built. Then once it runs, `make budget` reports the live VRAM/CGRAM/OAM
+> footprint of a scene via luna. The first bounds what you *built* (an upper
+> bound — a streaming game ships more than fits at once); the second measures
+> what a scene actually *loads* (a lower bound — non-zero content at one frame).
+> Between them you know where you stand. Add `ARGS="--only <name>"` to focus
+> either on one example.
 
 ## Choose a background mode from your genre
 

--- a/docs/craft/planning.md
+++ b/docs/craft/planning.md
@@ -107,6 +107,34 @@ BG3) so it draws over the action; see @ref craft_backgrounds for how to
 compose layers, and @ref examples_backgrounds_mode1_bg3_priority for the HUD
 overlay in practice.
 
+### The cost side: tiles by mode
+
+Each mode also trades layers and colour depth against **how much VRAM a tile
+costs**, because a tile's size is fixed by its colour depth (@ref
+snes_graphics_guide for the register detail):
+
+| Mode | Layers (colours) | Bytes/tile | The budget trade |
+|------|------------------|-----------|------------------|
+| 0 | BG1–BG4, all 4-colour (2bpp) | 16 each | Cheapest tiles, most layers — 3 colours + transparent per layer. Grids, menus, board games. |
+| **1** | BG1+BG2 16-colour (4bpp), BG3 4-colour (2bpp) | 32 / 32 / 16 | Two rich layers + a cheap HUD/backdrop. The default — best colour-per-byte balance. |
+| 2 | BG1+BG2 16-colour (4bpp) | 32 each | Two rich layers with per-column scroll (offset-per-tile); you give up BG3. |
+| 3 | BG1 256-colour (8bpp), BG2 16-colour (4bpp) | 64 / 32 | One lavish layer at **2× tile cost** — and rich art dedupes poorly, so a full 8bpp screen runs ~40 KB. No room for a second big layer. See @ref examples_backgrounds_mode3. |
+| 4 | BG1 256-colour (8bpp), BG2 4-colour (2bpp) | 64 / 16 | An 8bpp main layer plus a cheap second one, with per-column scroll. |
+| 5 | BG1 16-colour (4bpp), BG2 4-colour (2bpp), hi-res | 32 / 16 | Double horizontal resolution (512 px) — the wider display means bigger maps and a tighter sprite budget. |
+| 6 | BG1 16-colour (4bpp), hi-res | 32 | One hi-res layer with per-column scroll. |
+| 7 | one 256-colour (8bpp) layer, rotate/scale | 64 | Rotation and scaling in hardware, at a **fixed** cost: the 128×128 map is always 16 KB and tiles cap at 256 (16 KB) — roughly 32 KB whatever you draw. See @ref examples_mode7_rotate_scale. |
+
+Two patterns are worth internalising. **8bpp doubles your tile cost** (Modes 3,
+4, 7), and a **painterly image dedupes badly** — a game tileset reuses sky and
+bricks down to a few KB, but a near-photographic screen keeps most of its 896
+cells (32×28) as unique tiles. Together that is why one Mode 3 screen can cost
+40 KB while a Mode 1 playfield costs about 3 KB. Mode 7 is the odd one out: its
+cost is *fixed* by the 128×128 map, not by your art.
+
+> **See it as numbers.** `make asset-budget` prints exactly this per example —
+> the tile/map/palette weight of every mode in the library — so you can weigh
+> the trade against a real scene before committing to a mode.
+
 ## Scope a first game you can finish
 
 The community's hardest-won lesson, repeated across SNESdev game-jam devlogs:

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -23,6 +23,10 @@ Write game logic in C, produce .sfc ROMs that run on emulators or real hardware.
 
 @subpage craft -- Design decisions: budgeting, choosing a mode, composing layers
 
+## Tools
+
+@subpage tools -- The asset pipeline: turn images, maps, fonts and audio into SNES data
+
 ## Tutorials
 
 @subpage tutorial_graphics -- Graphics & Backgrounds

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,0 +1,74 @@
+# The OpenSNES toolbox {#tools}
+
+Your game is written in C, but the SNES does not eat PNGs, Tiled maps, or WAV
+files — it eats tiles, tilemaps, BGR555 palettes, BRR samples, and SPC700
+soundbanks. The OpenSNES tools are the converters that bridge the two: each takes
+an artist- or musician-friendly source format and emits the exact binary the
+hardware (and this SDK's runtime) expects.
+
+You rarely run most of them by hand — the build system wires the common ones in,
+so dropping a `.png` or `.wav` in an example's `res/` is usually enough. But
+knowing what each tool does, and which knobs it exposes, is what takes you from
+"the example builds" to "I shaped my own assets on purpose." That confidence is
+what this section is here to give.
+
+## The pipeline
+
+Most assets flow through a short, one-way pipeline from source art to ROM data:
+
+```
+  RGB art ──► img2snes ──► gfx4snes ──► tmx2snes ──► map engine
+   (.png)     (quantize)   (tiles +     (Tiled map     (mapLoad)
+                            palette +     + that .map
+                            tilemap)      → map binaries)
+
+  font.png ──► font2snes ──► text tiles      (dmaCopyVram)
+  sound.wav ─► wav2brr   ──► .brr sample     (audioLoadSample)
+  music.it ──► smconv    ──► SNESMOD bank    (spcLoad / spcPlay)
+```
+
+Each tool does exactly one conversion; the Makefile chains them. It is the
+Unix-pipe idea applied to asset building — small, composable, individually
+testable steps rather than one opaque converter.
+
+## The tools at a glance
+
+| Tool | Turns… | …into | In your build |
+|------|--------|-------|---------------|
+| @subpage tools_gfx4snes | an indexed PNG/BMP | tiles + palette + tilemap | auto (drop a PNG in `GFXSRC`) |
+| @subpage tools_tmx2snes | a Tiled JSON map | tilemap + collision + objects | one line per example |
+| @subpage tools_img2snes | RGB/RGBA artwork | a palette-indexed PNG (feeds gfx4snes) | manual pre-step |
+| @subpage tools_font2snes | a 96-glyph font PNG | 2bpp/4bpp text tiles | manual, optional |
+| @subpage tools_wav2brr | a PCM `.wav` | a `.brr` sound sample | auto (drop a WAV in `res/`) |
+| @subpage tools_smconv | an Impulse Tracker `.it` | a SNESMOD soundbank | auto (`USE_SNESMOD`) |
+
+## Three levels of wiring
+
+The tools sit at three levels of automation — worth knowing so you reach for the
+right one:
+
+1. **Zero-config, automatic.** `gfx4snes` (via the `GFXSRC` Makefile variable)
+   and `wav2brr` (any `res/*.wav`) and `smconv` (`USE_SNESMOD := 1`) run for you
+   during `make`. Drop the source in, reference the output, done.
+2. **One explicit line.** `tmx2snes` is called from an example's own Makefile,
+   because a Tiled project has choices (which layers, which extra outputs) the
+   build cannot guess.
+3. **By hand, when you need them.** `img2snes` (RGB → indexed) and `font2snes`
+   (custom font) are standalone pre-steps you run once and commit the result.
+   Looping `wav2brr` samples are also hand-built (the loop points are yours).
+
+All binaries live in `bin/` and are built by `make tools`. Every tool prints
+`--help`; the pages here are the guided version.
+
+## Where they fit with the rest of the docs
+
+- The **why** behind the numbers these tools produce — bpp, VRAM cost, palette
+  conventions — is @ref craft_planning. Read it before you commit to a mode.
+- The **level workflow** that `gfx4snes` + `tmx2snes` enable end-to-end is
+  @ref craft_tiles_to_levels and the @ref tutorial_map tutorial.
+- The **audio** side pairs with @ref snes_sound_guide and @ref tutorial_audio.
+
+> **The one rule.** Keep the *source* (the PNG, the Tiled project, the WAV, the
+> `.it`) as your single source of truth and let the tools regenerate the binary
+> on every build. The moment you hand-edit a `.pic` or a `.brr`, it drifts from
+> its source and you have lost the pipeline's whole benefit.

--- a/docs/tools/font2snes.md
+++ b/docs/tools/font2snes.md
@@ -1,0 +1,63 @@
+# font2snes — font images to text tiles {#tools_font2snes}
+
+The text module ships with a built-in font, so you may never need this tool. But
+when you want your *own* typeface — a chunky title font, a themed UI face —
+`font2snes` converts a font image into the SNES text tiles the text routines
+draw from.
+
+## What goes in, what comes out
+
+**In:** an indexed `.png` holding exactly **96 characters** (ASCII 32–127, so
+character 0 is the space), with dimensions that are multiples of 8.
+
+**Out:** either a binary `.pic` of tiles (default), or a C header (`-c`)
+declaring `const unsigned char <name>_data[]` you can `#include` and upload at
+runtime.
+
+## The flags you will actually use
+
+| Flag | Meaning |
+|------|---------|
+| `-b N` | bits per pixel: 2 (default) or 4 (4 for Mode 1 BG1/BG2 text) |
+| `-c` | emit a C header instead of a binary `.pic` |
+| `-v` | verbose |
+
+Note the argument style: font2snes takes **positional** `input output`, unlike
+gfx4snes's `-i`.
+
+## Worked examples
+
+```sh
+# 2bpp font as a C header (drop-in, no separate asset file):
+font2snes -c myfont.png myfont.h
+
+# 4bpp font for a 16-colour text layer:
+font2snes -b 4 -c font.png font.h
+
+# Binary tiles instead of a header:
+font2snes myfont.png myfont.pic
+```
+
+Then load it at runtime and point the text engine at it — a custom font is just
+tiles in VRAM, uploaded like any other:
+
+```c
+#include "myfont.h"
+dmaCopyVram(myfont_data, FONT_VRAM_ADDR, sizeof(myfont_data));
+```
+
+## Gotchas worth knowing up front
+
+- **Exactly 96 glyphs, ASCII 32–127.** Character cell 0 must be the space (ASCII
+  32). The layout is auto-detected — a 128×48 grid (recommended), a 768×8 strip,
+  or any N×M whose cell count is 96.
+- **Positional args.** It is `font2snes input output`, not `-i`/`-o`.
+- **Optional tool.** font2snes is not wired into the build and no example needs
+  it — `textLoadFont` already gives you a usable font. Reach for font2snes only
+  when you want a custom typeface; see the notes in the `examples/text/` README.
+
+## Where it fits
+
+A side-branch of the @ref tools pipeline: `font.png` → font2snes → text tiles.
+For drawing text with the built-in font (the common case), start from the text
+examples such as @ref examples_text_print_string instead.

--- a/docs/tools/gfx4snes.md
+++ b/docs/tools/gfx4snes.md
@@ -1,0 +1,92 @@
+# gfx4snes — images to tiles, palettes & maps {#tools_gfx4snes}
+
+`gfx4snes` is the cornerstone of the asset pipeline. It takes an indexed image
+and produces the three things a background (or a sprite sheet) is made of on the
+SNES: **tile graphics**, a **palette**, and — for backgrounds — a **tilemap**.
+Almost every visual example in the SDK starts here.
+
+## What goes in, what comes out
+
+**In:** a `.png` or `.bmp` that is **256-colour *indexed*** — not RGB. (Artist
+art in RGB must pass through @ref tools_img2snes first; that is the single most
+common gfx4snes mistake.)
+
+**Out**, depending on flags:
+
+| File | What it is | Loaded with |
+|------|-----------|-------------|
+| `.pic` | tile graphics (2/4/8bpp bitplanes) | `dmaCopyVram` / `bgInitTileSet` |
+| `.pal` | palette, BGR555, 2 bytes/colour | `dmaCopyCGram` |
+| `.map` | 16-bit tilemap entries (tile + flip + palette + priority) | `dmaCopyVram` / the map engine |
+| `.inc` | C size constants for the above | `#include` |
+| `.pc7` / `.mp7` | Mode 7 packed tiles / tilemap | Mode 7 setup |
+
+## The two flags that decide everything: `-u` and `-s`
+
+Colour depth is not a `--bpp` flag — it is implied by `-u` (colours *used* per
+tile), and it drives the VRAM cost you budgeted in @ref craft_planning —
+
+| `-u` | Depth | Bytes/tile | Use for |
+|------|-------|-----------|---------|
+| `-u 4` | 2bpp (4 colours) | 16 | Mode 0 layers, HUD/BG3, cheap backdrops |
+| `-u 16` | 4bpp (16 colours) | 32 | the workhorse — Mode 1 BG1/BG2, most sprites |
+| `-u 256` | 8bpp (256 colours) | 64 | Mode 3 / Mode 7 lavish single layers |
+
+And `-s` sets the tile/cell size: `-s 8` for backgrounds, `-s 16` (or 32/64) for
+sprites and metasprites.
+
+## The flags you will actually use
+
+| Flag | Meaning |
+|------|---------|
+| `-i FILE` | input image (**required**) |
+| `-s N` | cell size 8/16/32/64 (8 = BG, 16 = sprite) |
+| `-u N` | colours per tile → bit depth (4 / 16 / 256) |
+| `-o N` | how many colours to write to `.pal` (e.g. `-o 16`) |
+| `-p` | emit the palette `.pal` |
+| `-m` | emit the tilemap `.map` (backgrounds; **omit for sprites**) |
+| `-e N` | palette-bank offset (0–7) baked into tilemap entries |
+| `-c FILE` | impose a fixed palette — build fails if the image needs a colour not in it |
+| `-t png\|bmp` | force the input type |
+| `-y` | tilemap as 32×32 pages (for scrolling) · `-z` LZ77 · `-F` dedupe flipped |
+
+## Worked examples
+
+```sh
+# A 4bpp background for Mode 1 (tiles + palette + map):
+gfx4snes -s 8 -o 16 -u 16 -p -m -i background.png
+
+# A 2bpp background for Mode 0 (from a BMP):
+gfx4snes -s 8 -o 4 -u 4 -e 0 -p -m -t bmp -i tiles.bmp
+
+# A 16×16 sprite sheet (tiles + palette, no map):
+gfx4snes -s 16 -p -i sprites.png
+
+# With a fixed, authored palette so colours never drift (recommended):
+gfx4snes -s 8 -o 16 -u 16 -p -m -c res/town_fixed.pal -i tileset.png
+```
+
+In the SDK you rarely type these: set `GFXSRC := background.png` in the example
+Makefile and the zero-config rule runs `gfx4snes -s $(SPRITE_SIZE) -p` for you.
+Add `-m`, `-c`, and friends when you outgrow the default.
+
+## Gotchas worth knowing up front
+
+- **Indexed input only.** RGB/RGBA art produces garbage or an error — run
+  @ref tools_img2snes first.
+- **The silent re-hue.** Without `-c`, gfx4snes derives the palette from the
+  *whole* image, so adding one tile can quietly change the colours of every
+  existing tile (a real regression the RPG example hit). Pin the palette with
+  `-c` once your colours are settled.
+- **bpp is `-u`, not a bpp flag** — the most common source of confusion.
+- **Sprites skip `-m`** — a sprite sheet has no tilemap.
+
+## See it in practice
+
+- @ref examples_backgrounds_mode0 — 2bpp, four cheap layers.
+- @ref examples_backgrounds_mode3 — 8bpp, and why one screen costs ~40 KB.
+- @ref examples_games_rpg — fixed-palette backgrounds *and* `-s 16` sprites.
+- @ref examples_input_move_sprite — the simplest sprite-tile case.
+
+Next in the pipeline: feed the `.map` this produces into @ref tools_tmx2snes to
+turn a Tiled level into ready-to-load map binaries.

--- a/docs/tools/img2snes.md
+++ b/docs/tools/img2snes.md
@@ -1,0 +1,63 @@
+# img2snes — RGB artwork to indexed palettes {#tools_img2snes}
+
+`gfx4snes` needs **indexed** images, but artists work in RGB. `img2snes` is the
+bridge: it quantises a full-colour PNG down to a SNES-legal indexed palette, so
+your artwork feeds the rest of the pipeline without hand-editing palettes in an
+image editor. Run it once on new art, commit the indexed result, and gfx4snes
+takes it from there.
+
+## What goes in, what comes out
+
+**In:** a `.png` — RGB, RGBA, or already indexed.
+
+**Out:** a palette-indexed `.png` (2–256 colours, palette embedded). The default
+name is `<input>_indexed.png`.
+
+## The flags you will actually use
+
+| Flag | Meaning |
+|------|---------|
+| `-i FILE` | input image (**required**) |
+| `-o FILE` | output path (default `<input>_indexed.png`) |
+| `-c N` | number of colours, 2–256 (16 for 4bpp, 4 for 2bpp, 256 for 8bpp) |
+| `--round-snes` | snap the palette to SNES BGR555 (multiples of 8) — **recommended** |
+| `-p FILE` | match pixels to an existing PNG's palette (shared palette across sprites) |
+| `-s FACTOR` | nearest-neighbour scale |
+| `-t N` | pad dimensions up to a multiple of N (e.g. 8) |
+| `--batch` | treat the input as a glob and convert many files |
+
+## Worked examples
+
+```sh
+# Quantise a character sprite to 16 colours, SNES-rounded:
+img2snes -i character.png -c 16 --round-snes
+
+# A 4-colour (2bpp) font source, explicit output name:
+img2snes -i font.png -c 4 -o font_4col.png
+
+# Force several sprites to share one palette (pass a reference PNG):
+img2snes -i enemy.png -p hero_indexed.png
+```
+
+Then hand the indexed PNG to @ref tools_gfx4snes with a matching `-u` (16
+colours → `-u 16`, etc.).
+
+## Gotchas worth knowing up front
+
+- **Transparency = index 0.** Pixels with alpha below 128 map to colour 0, which
+  the SNES treats as transparent — so paint your background in fully-transparent
+  pixels, not a "magic" colour.
+- **`--round-snes` early.** The SNES only has 15-bit colour; rounding at
+  quantisation time means what you see is what the hardware shows, with no
+  surprise shifts later.
+- **`-p` for shared palettes.** When several sprites must live in one 16-colour
+  sub-palette (the @ref craft_planning constraint), quantise the first, then map
+  the rest onto its palette with `-p`.
+- **Optional and standalone.** img2snes is not wired into the build — it is a
+  one-time artist pre-step. Its output is what you commit and reference.
+
+## Where it fits
+
+img2snes is the very first box in the @ref tools pipeline: RGB art → indexed PNG
+→ @ref tools_gfx4snes → tiles/palette/map. If your source art is already indexed
+(pixel-art tools often export that way), you can skip it entirely.

--- a/docs/tools/smconv.md
+++ b/docs/tools/smconv.md
@@ -1,0 +1,84 @@
+# smconv — tracker modules to SNESMOD soundbanks {#tools_smconv}
+
+`smconv` turns music written in a tracker — Impulse Tracker `.it` modules — into
+a **SNESMOD soundbank**: the packed music, samples, and effect data the SPC700
+plays. It is how you get real, multi-channel music (and sound-effect banks) into
+a game, driven from C by a few `spcLoad` / `spcPlay` calls.
+
+## What goes in, what comes out
+
+**In:** one or more `.it` files (each becomes a numbered module — songs and/or
+SFX banks).
+
+**Out** (soundbank mode, `-s`):
+
+| File | What it is | Used by |
+|------|-----------|---------|
+| `<base>.asm` | the soundbank data (assembled into the ROM) | the build |
+| `<base>.h` | C constants for each module and effect | your game code |
+| `<base>.brr` | the BRR sample data | the soundbank |
+
+Without `-s`, smconv instead writes a single standalone `.spc` you can play in an
+SPC player — handy for auditioning a module outside the SDK.
+
+## How you actually use it
+
+You almost never call smconv directly. Declare it in the example Makefile and the
+build runs it with the right OpenSNES conventions:
+
+```makefile
+USE_SNESMOD  := 1
+SOUNDBANK_SRC := music/mysong.it     # one or more .it files
+```
+
+Under the hood that becomes:
+
+```sh
+smconv -s -o soundbank -b 1 -n -p soundbank music/mysong.it
+```
+
+Then, in C, load and play by module number (the `.h` gives you the names):
+
+```c
+spcLoad(MOD_MYSONG);   // load a module
+spcPlay(0);            // play it
+spcPlaySound(SFX_JUMP);// trigger a sound effect from an SFX bank
+```
+
+See @ref tutorial_audio and @ref snes_sound_guide for the runtime side.
+
+## The flags behind the Makefile
+
+| Flag | Meaning |
+|------|---------|
+| `-s` | soundbank mode (the game path; default is standalone `.spc`) |
+| `-o FILE` | output base name (**required** in soundbank mode) |
+| `-b N` | ROM bank for the soundbank data — **OpenSNES uses 1** (SNESMOD default is 5) |
+| `-n` | skip the `hdr.asm` include — **required** in OpenSNES |
+| `-p NAME` | symbol prefix (OpenSNES sets it to the output base) |
+| `-f` | check `.it` sizes against the first file (for SFX banks) |
+| `-i` | HiROM mapping · `-V` verbose (reports SPC RAM usage) |
+
+## Gotchas worth knowing up front
+
+- **Declare, don't invoke.** For a game build, set `USE_SNESMOD` and
+  `SOUNDBANK_SRC`; the bank (`-b 1`), no-header (`-n`) and prefix flags are
+  OpenSNES-specific and the Makefile gets them right. Calling smconv by hand with
+  SNESMOD's defaults will not link.
+- **Many modules, one bank.** Pass several `.it` files to get several modules —
+  music via `spcLoad(N)` + `spcPlay(0)`, effects via `spcPlaySound(N)`.
+- **SPC700 limits are real.** Up to 8 channels; samples auto-convert to BRR at
+  32 kHz max; `-V` reports how much of the SPC's 64 KB you are using — watch it,
+  because music and samples share that space.
+- **HiROM builds** relocate the soundbank origin (the build handles the `.ORG`
+  fix-up for you).
+
+## See it in practice
+
+- @ref examples_audio_snesmod_music — a full song playing.
+- @ref examples_audio_snesmod_sfx — a sound-effect bank.
+- @ref examples_games_likemario and @ref examples_games_tetris — music and SFX in
+  real games.
+
+For a single one-shot sample rather than a whole module, use @ref tools_wav2brr —
+it shares smconv's BRR encoder, so the samples sound identical.

--- a/docs/tools/tmx2snes.md
+++ b/docs/tools/tmx2snes.md
@@ -1,0 +1,87 @@
+# tmx2snes — Tiled levels to SNES map data {#tools_tmx2snes}
+
+`tmx2snes` is how a level you paint in [Tiled](https://www.mapeditor.org/)
+becomes something the SNES map engine can load and scroll. It takes a Tiled map
+exported as JSON, plus the tile-optimisation table from @ref tools_gfx4snes, and
+emits the binary tilemap, collision, and object files the runtime reads. It is
+the tool that makes @ref craft_tiles_to_levels a real workflow instead of a
+theory.
+
+## What goes in, what comes out
+
+**In** — two positional arguments, in this order:
+
+1. `map.tmj` — your Tiled map, **exported as JSON** (`.tmj`), not the XML `.tmx`.
+2. `tileset.map` — the `.map` file `gfx4snes` produced for the same tileset (it
+   lets tmx2snes reuse gfx4snes's tile de-duplication).
+
+**Out** — the defaults, always emitted:
+
+| File | Named after | What it is | Loaded with |
+|------|-------------|-----------|-------------|
+| `<layer>.m16` | the Tiled *layer* | the tilemap | `mapLoad` (arg 1) |
+| `<base>.t16` | the map | per-tile palette + priority | `mapLoad` (arg 2) |
+| `<base>.b16` | the map | per-tile attributes (collision behaviour) | `mapLoad` (arg 3) |
+| `<base>.o16` | the map | object positions + types | `objLoadObjects` |
+
+Opt-in outputs:
+
+| Flag | Adds | For |
+|------|------|-----|
+| `-e` | `<map>.inc` — the Entities layer as C `#define`s | referencing objects from game code |
+| `-Q` | `<layer>.q16` — a quadrant-ordered 64×64 tilemap | a `dmaCopyVram`-straight-to-VRAM map you scroll yourself |
+| `-C` | `<layer>.c16` — one collision byte per cell | `collideTile` on a plain grid |
+
+## How you actually use it
+
+Because a Tiled project has choices the build cannot guess, tmx2snes is called
+explicitly from the example's Makefile — typically from inside `res/`:
+
+```sh
+cd res && tmx2snes maplevel01.tmj tileslevel1.map
+```
+
+where the tileset `.map` came from, e.g.:
+
+```sh
+gfx4snes -s 8 -o 48 -u 16 -p -m -i tileset.png
+```
+
+Then in C you hand the three defaults to `mapLoad()` and scroll with the map
+engine — see @ref tutorial_map for the loading and scrolling code.
+
+## Authoring the level in Tiled
+
+The data lives in Tiled tile **custom properties**, which tmx2snes reads and
+bakes into the binaries — this is how a tile carries *meaning*, not just pixels
+(the idea developed in @ref craft_tiles_to_levels):
+
+| Tiled property | Type | Becomes |
+|----------------|------|---------|
+| `attribute` | hex string | the collision/behaviour byte (`.b16`) — solid, ladder, spike, slope… |
+| `palette` | "0"–"7" | which of the 8 sub-palettes the tile uses |
+| `priority` | "0" / "1" | whether the tile draws in front of sprites |
+
+Objects (spawns, doors, triggers) go in an **objectgroup** layer named
+`Entities`; each object's Tiled *type* groups it in the `.o16` / `.inc` output.
+
+## Gotchas worth knowing up front
+
+- **JSON, not XML.** Export the map as `.tmj` (Tiled: *File → Export As → JSON*).
+  The XML `.tmx` is the editor's own format; the tool ingests the JSON export.
+- **8×8 tiles only**, up to 16384 tiles, height ≤ 256.
+- **Layer name = filename.** A layer called `BG1` yields `BG1.m16`. Name your
+  layers deliberately.
+- **`-h`, not `--help`.** The long form is not recognised (it prints usage
+  anyway).
+- **`-C` reflects the map only.** Runtime blockers (an NPC standing in a
+  doorway) are a game-logic decision, not baked into the collision grid.
+
+## See it in practice
+
+- @ref examples_maps_tiled — the complete Tiled → SNES worked example.
+- @ref examples_maps_map_scroll — the map engine scrolling a level wider than VRAM.
+- @ref examples_games_rpg — a full game driving its world from Tiled.
+
+Upstream of this: @ref tools_gfx4snes makes the tileset and the `.map` table
+tmx2snes needs.

--- a/docs/tools/wav2brr.md
+++ b/docs/tools/wav2brr.md
@@ -1,0 +1,61 @@
+# wav2brr — WAV to BRR sound samples {#tools_wav2brr}
+
+The SNES sound chip plays samples in its own compressed format, **BRR** (Bit
+Rate Reduction — a 9-byte block per 16 samples). `wav2brr` encodes an ordinary
+PCM `.wav` into a `.brr` you load at runtime with `audioLoadSample()`. It is the
+zero-config path for one-shot sound effects.
+
+## What goes in, what comes out
+
+**In:** a PCM `.wav` — 8- or 16-bit, mono or stereo (stereo is downmixed).
+
+**Out:** a raw `.brr` (its size is always a multiple of 9 bytes). Default name is
+`input.brr` alongside the input.
+
+## The flags you will actually use
+
+| Flag | Meaning |
+|------|---------|
+| `--loop START END` | loop between sample indices START..END (default: one-shot, no loop) |
+| `-v` | verbose — prints the size breakdown, a sample-rate warning, and a ready-to-paste load line |
+
+## How you actually use it
+
+**One-shot SFX — automatic.** Drop a `.wav` in the example's `res/` and
+`.incbin` the matching `.brr` in an ASM file; the build's `%.brr: %.wav` rule
+runs `wav2brr` for you. No command to type:
+
+```
+res/blip.wav   ──(make)──►   res/blip.brr   ──.incbin──►   audioLoadSample()
+```
+
+**Looping samples — by hand.** A sustained instrument or a looping ambience needs
+loop points, which only you know, so build it once and commit the `.brr`:
+
+```sh
+wav2brr --loop 512 2048 instrument.wav instrument.brr
+```
+
+Run with `-v` to see the block count and the exact `audioLoadSample()` call to
+paste.
+
+## Gotchas worth knowing up front
+
+- **Keep the source at or below 32 kHz.** That is the DSP's output ceiling; a
+  higher-rate WAV is accepted but plays sharp (a note higher than authored). `-v`
+  warns when it happens. The pitch you hear is set at *playback* by the DSP pitch
+  value, relative to the sample's rate — see @ref snes_sound_guide.
+- **Looping bypasses the auto-rule.** The zero-config path makes one-shots only;
+  anything with `--loop` is a hand-built, committed asset.
+- **Deterministic and shared.** wav2brr uses the same BRR encoder as
+  @ref tools_smconv, so a sample sounds identical whether it is a standalone SFX
+  or baked into a soundbank (golden-tested via `make test-tools`).
+
+## See it in practice
+
+- @ref examples_audio_sfx_from_wav — one-shots auto-generated from `res/*.wav`.
+- @ref examples_audio_soundboard — committed `.brr` blobs, `.incbin`'d and played
+  with per-voice volume/pan/pitch.
+
+For music (as opposed to individual samples), you want @ref tools_smconv and its
+tracker-module workflow instead.

--- a/lib/include/snes.h
+++ b/lib/include/snes.h
@@ -53,13 +53,13 @@
 #define OPENSNES_VERSION_MAJOR 0
 
 /** @brief OpenSNES minor version */
-#define OPENSNES_VERSION_MINOR 34
+#define OPENSNES_VERSION_MINOR 35
 
 /** @brief OpenSNES patch version */
 #define OPENSNES_VERSION_PATCH 0
 
 /** @brief OpenSNES version string */
-#define OPENSNES_VERSION_STRING "0.34.0"
+#define OPENSNES_VERSION_STRING "0.35.0"
 
 /*============================================================================
  * Core Headers

--- a/make/common.mk
+++ b/make/common.mk
@@ -469,6 +469,16 @@ ifneq ($(SKIP_RAM_CHECK),1)
 		fi; \
 	fi
 endif
+	@# PPU asset budget — a per-build instrument (VRAM/CGRAM weight of the
+	@# converted graphics on disk), the build-time twin of `make budget`
+	@# (runtime footprint via luna). Report-only, NEVER a gate: an inventory
+	@# over 100% is legitimate (streaming, per-scene/per-scanline palette
+	@# swaps), so it only prints the number, no alarm. Silent for asset-less
+	@# examples. `|| true` keeps a tool hiccup from ever failing a build.
+	@# Set SKIP_ASSET_BUDGET=1 to disable; see docs/craft/craft_planning.
+ifneq ($(SKIP_ASSET_BUDGET),1)
+	@python3 $(OPENSNES)/devtools/asset_budget.py --oneline "$(CURDIR)" || true
+endif
 	@# Bank-blind C reads of bank $$01+ data (issue #104): the read-side
 	@# symmetric of the spill ratchet. A symbol deref'd from C without a
 	@# bank reference must be linked in bank $$00 — otherwise the 16-bit


### PR DESCRIPTION
## [0.35.0] — 2026-08-07

A documentation-and-tooling release. The developer-experience push from 0.34.0
continues: a static, build-time asset-budget report to pair with the runtime
one, a complete **Tools** documentation section so newcomers discover and learn
every asset converter from the docs, and two more game-craft guides.

### Added
- feat(devtools,build): **static VRAM/CGRAM asset-budget report** — a new
  `make asset-budget` command that weighs the converted graphics on disk (tiles
  and maps → VRAM, palettes → CGRAM) against the 64 KB / 256-colour limits, the
  build-time twin of the runtime `make budget`. It also prints a compact
  `[ASSETS]` instrument line at every example link (silent for asset-less
  builds, `SKIP_ASSET_BUDGET=1` to disable). Report-only, never a gate — an
  inventory upper bound, since streaming and palette swaps legitimately exceed
  the limits.

### Documentation
- docs(tools): a **complete Tools documentation section** (`docs/tools/`) — a
  toolbox landing page plus a presentation-and-tutorial page for each converter
  (gfx4snes, tmx2snes, img2snes, font2snes, wav2brr, smconv), wired into the
  doc site and nav. Facts verified against each tool's README and live `--help`.
- docs(craft): two **craft companions** — *camera* (deadzone, look-ahead,
  platform snapping, room-locking, all derived from one camera value) and
  *game-feel* (screen shake, hit flash via color math, hitstop, fades, palette
  cycling — the SNES-specific tricks).
- docs(craft): a **cost-by-mode table** in the planning guide — per-mode layer
  layout, bytes/tile by colour depth, and the VRAM trade for each background
  mode.
- docs(rules): the **luna-first** transitory-tooling convention (internal
  contributor rule) — everything validates through luna; internal scripts are
  transitory prototypes to be retired once luna owns the capability.