### PR TITLE
ci: move the workflows' actions to their Node 24 majors

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES (full history)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # need full history for the range walk
 
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run lint_asm.py
         # Hand-written ASM in lib/source and templates must declare the
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run check_doc_drift.py
         # Anchored claims that drift behind code: version macros in
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run test_check_nmi_wram_race.py
         # Regression suite for devtools/check_nmi_wram_race.py — the
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run test_symmap.py
         # Regression suite for devtools/symmap/symmap.py --check-overlap, the
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run check_vram_layout.py
         # BG/sprite VRAM bases are programmed through registers that store only
@@ -163,7 +163,7 @@ jobs:
       - name: Check out OpenSNES (with submodules)
         # `make tools` runs the top-level verify-toolchain dependency, which
         # needs the compiler submodules checked out.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -184,7 +184,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Doxygen 1.16.1 (pinned — must match deploy_docs.yml)
         # ubuntu's Doxygen 1.9.8 has a severe Markdown bug; the guard must test

--- a/.github/workflows/msys2_cproc_diagnostic.yml
+++ b/.github/workflows/msys2_cproc_diagnostic.yml
@@ -39,7 +39,7 @@ jobs:
             git
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -182,7 +182,7 @@ jobs:
           ls -la diag_output/ 2>/dev/null || echo "(empty)"
 
       - name: Upload diagnostics
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: msys2-cproc-diagnostics

--- a/.github/workflows/opensnes_build.yml
+++ b/.github/workflows/opensnes_build.yml
@@ -89,7 +89,7 @@ jobs:
       # Checkout the project                 #
       # ------------------------------------ #
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -99,7 +99,7 @@ jobs:
       # each build (~20-30s/leg; the rest — lib+examples+docs+zip — still runs).
       - name: Restore prebuilt toolchain
         id: toolchain
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             bin
@@ -180,7 +180,7 @@ jobs:
       # `make release`, so a failed build never poisons the cache).
       - name: Save prebuilt toolchain (cache miss only)
         if: steps.toolchain.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             bin
@@ -281,7 +281,7 @@ jobs:
       # Upload SDK release                   #
       # ------------------------------------ #
       - name: Upload OpenSNES SDK release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: OpenSNES SDK (${{ matrix.name }}_${{ matrix.arch }})
           path: release/opensnes_${{ matrix.name }}_${{ matrix.arch }}.zip
@@ -290,7 +290,7 @@ jobs:
       # Upload build logs                    #
       # ------------------------------------ #
       - name: Upload build logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: OpenSNES Logs (${{ matrix.name }})
@@ -321,7 +321,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out OpenSNES (with submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -333,7 +333,7 @@ jobs:
       # toolchain build).
       - name: Restore prebuilt toolchain
         id: toolchain
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             bin
@@ -362,7 +362,7 @@ jobs:
 
       - name: Save prebuilt toolchain (cache miss only)
         if: steps.toolchain.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             bin
@@ -453,7 +453,7 @@ jobs:
 
       - name: Upload luna artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: luna-test artifacts
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # need full history to walk merge-base
 
@@ -94,7 +94,7 @@ jobs:
       # Checkout the project                 #
       # ------------------------------------ #
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -104,7 +104,7 @@ jobs:
       # seeds it. See opensnes_build.yml for the full rationale.
       - name: Restore prebuilt toolchain
         id: toolchain
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             bin
@@ -163,7 +163,7 @@ jobs:
 
       - name: Save prebuilt toolchain (cache miss only)
         if: steps.toolchain.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             bin
@@ -215,7 +215,7 @@ jobs:
       # Upload zip as artifact for release   #
       # ------------------------------------ #
       - name: Upload release zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: opensnes-${{ steps.version.outputs.tag }}-${{ matrix.name }}-${{ matrix.arch }}
           path: release/opensnes_${{ steps.version.outputs.tag }}_${{ matrix.name }}_${{ matrix.arch }}.zip
@@ -228,10 +228,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 
@@ -279,7 +279,7 @@ jobs:
           NOTESEOF
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.version }}
           name: OpenSNES ${{ steps.tag.outputs.version }}


### PR DESCRIPTION
The v0.39.0 and v0.40.0 release runs logged "Node.js 20 is deprecated"
for actions/checkout@v4, actions/cache/{restore,save}@v4,
actions/upload-artifact@v4, actions/download-artifact@v4 and
softprops/action-gh-release@v2. Bumped to the first majors that run on
Node 24: checkout v5, cache v5, upload-artifact v5, download-artifact v6
(v5 changed the path layout of single-artifact downloads by id, which
we do not use; the release job downloads every artifact into artifacts/
as before), action-gh-release v3 (runtime move only, same inputs).
peaceiris/actions-gh-pages@v4 and msys2/setup-msys2@v2 were not in the
notice and stay.

Validated by the build and lint workflows on the PR into develop; the

https://claude.ai/code/session_01SaBKev4cAfdNKbSVg9zePf