### PR TITLE
ci: upload-artifact v6 and download-artifact v7 — the majors that actually run on Node 24

### DIFF
--- a/.github/workflows/msys2_cproc_diagnostic.yml
+++ b/.github/workflows/msys2_cproc_diagnostic.yml
@@ -182,7 +182,7 @@ jobs:
           ls -la diag_output/ 2>/dev/null || echo "(empty)"
 
       - name: Upload diagnostics
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: msys2-cproc-diagnostics

--- a/.github/workflows/opensnes_build.yml
+++ b/.github/workflows/opensnes_build.yml
@@ -281,7 +281,7 @@ jobs:
       # Upload SDK release                   #
       # ------------------------------------ #
       - name: Upload OpenSNES SDK release
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: OpenSNES SDK (${{ matrix.name }}_${{ matrix.arch }})
           path: release/opensnes_${{ matrix.name }}_${{ matrix.arch }}.zip
@@ -290,7 +290,7 @@ jobs:
       # Upload build logs                    #
       # ------------------------------------ #
       - name: Upload build logs
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: OpenSNES Logs (${{ matrix.name }})
@@ -453,7 +453,7 @@ jobs:
 
       - name: Upload luna artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: luna-test artifacts
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
       # Upload zip as artifact for release   #
       # ------------------------------------ #
       - name: Upload release zip
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: opensnes-${{ steps.version.outputs.tag }}-${{ matrix.name }}-${{ matrix.arch }}
           path: release/opensnes_${{ steps.version.outputs.tag }}_${{ matrix.name }}_${{ matrix.arch }}.zip
@@ -231,7 +231,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download all release artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 


### PR DESCRIPTION
#146 moved upload-artifact to v5 and download-artifact to v6 on the
strength of their release notes ("supports Node v24"), but their
action.yml still declares `runs.using: node20` — the build run kept
logging the deprecation notice three times, once per upload step.
Checked every candidate's action.yml: upload-artifact v6 and
download-artifact v7 are the first to declare node24 (v8 of
download-artifact adds enforced checks, not needed). checkout v5,
cache v5 and action-gh-release v3 were already node24.

https://claude.ai/code/session_01SaBKev4cAfdNKbSVg9zePf