### PR TITLE
release: v0.41.0

### DIFF
--- a/.claude/STRUCTURAL_DEFECTS.md
+++ b/.claude/STRUCTURAL_DEFECTS.md
@@ -1479,8 +1479,8 @@ bank-honouring; `sym[idx]` is absolute long indexed (cheaper than bank
 0), pointer walks within 4 % of near; init records carry a bank byte;
 crt0 zero-fills `$7E:2000-$FFFF`; `const T *` accepts `T FAR *`.
 breakout and dsp1_ground migrated, fbhash identical. Two side findings:
-HDMA enabled mid-frame ran on stale A2A/NTRL (fixed in `hdmaSetup*`, hw
-claim to verify against the corpus) and the `cst`/`farram` access flag
+HDMA enabled mid-frame ran on stale A2A/NTRL (fixed in `hdmaSetup*`,
+arbitrated against the corpus 2026-09-07: anomie-regs, snesdev-wiki) and the `cst`/`farram` access flag
 pins loads in QBE's optimiser (follow-up chantier, §10b of the note).
 Original entry kept below for the record.
 

--- a/.claude/STRUCTURAL_DEFECTS.md
+++ b/.claude/STRUCTURAL_DEFECTS.md
@@ -59,7 +59,9 @@ load-bearing for cross-session continuity).
 >   `.claude/notes/chantiers/qbe_access_flag.md`).
 > - **INTRINSIC (not fixable):** D3 (SuperFX has no C compiler — GSU RISC ISA).
 > - **Cross-ref:** the only *public* open issue is **#127** (its remaining
->   piece, #127.3, = QBE const-data default placement). Everything else
+>   piece, #127.3 = QBE const-data default placement, **shipped
+>   2026-09-07** — bank $00 minimum 12 → 2168 bytes, HiROM fixed with
+>   `.BASE $C0` + a wlalink patch). Everything else
 >   here is maintainer-internal.
 
 **Baseline**: external review delivered 2026-05-07; 18 commits shipped on

--- a/.claude/STRUCTURAL_DEFECTS.md
+++ b/.claude/STRUCTURAL_DEFECTS.md
@@ -1255,8 +1255,13 @@ passes test bit 0 only and cproc's pointer-variable loads carry no
 pointee taint. The "latent bug" was the HDMA mid-frame glitch and the
 RNG boot seed (both explained in v0.39.0); the corpus is clean on the
 frame-equal protocol. Lib −685 instructions (−4.25 %), asset −34 % /
-anim −17 % / panel −15 % estimated cycles. No existing ROM bench
-exercises the gain (benchrom is ASM-path only) — recorded as a gap.
+anim −17 % / panel −15 % estimated cycles. Measured on the ROM bench
+once `devtools/benchrom` gained const-path workloads (2026-09-07, luna,
+cycles per call, v0.39.0 → v0.40.0): animTick 1224 → 989 (−19 %),
+animTickMeta 1346 → 1108 (−18 %), const u8 walk ×32 7689 → 6832
+(−11 %), const u16 walk ×32 7380 → 6522 (−12 %), const→RAM copy ×32
+9738 → 8881 (−9 %), const struct fields 676 → 310 (−54 %), `tab[i]`
+203 → 203 (already fused). The ASM rows are unchanged, as they must be.
 
 **Acceptance criteria**: the three passes test bit 0 only; cproc's
 pointer-variable loads carry no pointee taint; corpus green on the

--- a/.claude/notes/chantiers/127_rodata_default_placement.md
+++ b/.claude/notes/chantiers/127_rodata_default_placement.md
@@ -1,8 +1,8 @@
 # #127 proposal 3 — default non-bank-$00 placement for QBE const data
 
-Status: **measured, not shipped.** The one-line default-flip is safe for
-LoROM and SA-1 and **corrupts HiROM**. Reverted. This note is so the next
-attempt starts from the HiROM problem instead of re-running the safe half.
+Status: **SHIPPED 2026-09-07** (branch `wip/127-rodata-default`). The
+HiROM problem below is solved — see "Resolution" at the end. The 2026-07
+analysis is kept as written.
 
 ## The experiment
 
@@ -107,3 +107,44 @@ re-derive it. The whole of the remaining work is HiROM.
 Nothing in the compiler. The reusable BANKS-`.DEFINE` mechanism
 (`6943eccb`) and `ASSET_SECTION` picking its own bank (`aeabdad3`) are in
 `develop`; this default-flip is not. #127 stays open on HiROM.
+
+## Resolution (2026-09-07)
+
+The HiROM culprit was neither the offset per se, nor `dmaCopyVram`, nor
+the SEMISUPERFREE directive: it was the **bank byte**. Every unit's
+`:label` / 24-bit address used base 0 (the header's `.BASE $80` only
+applies to the header's own file, and only under FASTROM), so a label at
+offset $0000 of linker bank 1 became `$01:0000` — the half of that bank
+HiROM does not map at $00-$3F. `SOUNDBANK` at `01:8000` worked because
+the upper half is mirrored there. The same bug already bit the runtime:
+`.mul32`/`.div32` sat at `07:0000` in hirom_demo, i.e. `$07:0000`, a WRAM
+mirror — any HiROM C program doing 32-bit arithmetic would have crashed.
+
+Fix, two parts:
+
+1. `.BASE $C0` in `memmap_hirom.inc` (every C TU and asm wrap) and in
+   `hdr_hirom.asm` (crt0): the bank byte is `$C0 + linker bank`, the full
+   64 KB view, also the FastROM window. Code at `$8000+` stays reachable
+   both ways.
+2. wla-dx applied `.BASE` to RAMSECTION labels too (`get_snes_pc_bank`:
+   `x = (x + l->base) << 16` for every label): `oamMemory` at `$7E:0300`
+   became `$13E:0301`, out of 24-bit range — and under `.BASE $80` a `$7E`
+   buffer silently became `$FE`. One patch on the fork
+   (`opensnes/ram-labels-ignore-base`, `86df331`): a label in a RAM
+   section keeps its declared bank. First local patch on wla-dx, a
+   deliberate decision (`.claude/rules/bank0_budget.md`).
+
+`symmap.py` and `check_bank_reads.py` fold `$C0-$FF` / `$80-$BF` back to
+the linker bank when reading a `.sym` (the `.sym` now prints `c0:8afc
+main`, `c7:0000 tcc_mul32`, `7e:0300 oamMemory` for hirom_demo — a valid
+CPU address per line, which luna needs).
+
+Then the flip itself (qbe `ca50db8`), both emission sites, and the
+symmap spill heuristics retired (a `.rodata` or `string.N` in bank $01+
+is the intent now; `check_bank_reads.py` is the guard that remains).
+
+Corpus, clean rebuild: visual **85/85 identical**, manifests 50/50,
+coverage unchanged, bank-blind lint 0/85, hirom_demo pixel-identical with
+its data in bank 7. Bank $00 minimum **12 → 2168 bytes** (mode5_hires);
+tetris/likemario/mapandobjects leave the 12-byte cliff for good. WRAM
+oracle re-baselined (layout shift → return addresses on the stack).

--- a/.claude/notes/chantiers/b2_far_ram.md
+++ b/.claude/notes/chantiers/b2_far_ram.md
@@ -472,10 +472,12 @@ HBlank reloads the real first entry and a mid-frame enable starts the
 table one line late and clean. Verified with luna: palette entries 1-15
 equal the ROM palette, h_scroll 0, and both examples render identically
 at frame-equal comparison between builds with and without the zero-fill
-(deterministic against boot timing now). The HBlank procedure this relies
-on (decrement, reload on zero) is anomie's; **to verify against the SNES
-corpus** — cartouche was unreachable in this session (see
-`.claude/rules/hardware_claims.md`, degrade path).
+(deterministic against boot timing now). **Arbitrated 2026-09-07** once
+cartouche was back: anomie-regs marks `$43x8-9` and `$43xA` as required
+for a mid-frame start ("do the init process manually by setting
+$43x8-A"), the snesdev VBlank-routine page names the symptom, the
+sfc-dev-wiki gives the per-scanline order. Citations are in
+`lib/source/hdma.asm`.
 
 ### 10g. Lessons
 

--- a/.claude/notes/chantiers/qbe_access_flag.md
+++ b/.claude/notes/chantiers/qbe_access_flag.md
@@ -104,7 +104,11 @@ Rebuilt from clean; reference ROMs = the v0.39.0 build.
   paths — mode7, map, dynamic sprites — with no pinned access); the
   "instructions to frame F" proxy is *inverted* for idle-heavy ROMs
   (luna counts the halted `wai` loop) and flat for CPU-bound ones. No
-  existing bench measures this gain; the static numbers are the record.
+  existing bench measured this gain at the time; `devtools/benchrom` has
+  since gained const-path workloads (2026-09-07) — v0.39.0 → v0.40.0,
+  cycles per call: animTick 1224 → 989 (−19 %), animTickMeta 1346 → 1108
+  (−18 %), const u8/u16 walk ×32 −11/−12 %, const→RAM copy ×32 −9 %,
+  const struct fields 676 → 310 (−54 %), `tab[i]` unchanged (fused).
 - Correctness: `make test-compiler` 18/18, fixture 25/25, coverage
   83/85 unchanged, manifests 50/50, visual 81/85 with the 4 movers
   (basics_timer, games_shmup_1942, scrolling_parallax_scroll,

--- a/.claude/rules/bank0_budget.md
+++ b/.claude/rules/bank0_budget.md
@@ -107,29 +107,35 @@ because an earlier heuristic version flagged `.text.bgSetMapPtr` for
 containing "map", and a report you cannot trust is worse than none.
 Sections that opt out of the macro are simply not counted.
 
-### What still blocks making it the default
+### The default since #127.3 (2026-09-07)
 
-Issue #127's remaining piece is non-bank-$00 placement for C const data
-(`.rodata.N`, emitted by QBE) without an opt-in. Measured 2026-07-22, it
-needs one of:
+QBE now emits every C const datum as `.SECTION ".rodata.N" SEMISUPERFREE
+BANKS ASSET_BANKS` — the same directive as `ASSET_SECTION`, applied by
+the compiler. Nothing to opt into: `static const` tables, string
+literals and initialised const structs land in the asset banks (highest
+first) and bank $00 keeps code. What made it safe: every C read of const
+data is a far read (#121), every lib call carries a far pointer (A6), and
+`devtools/check_bank_reads.py` fails the link on any symbol in bank $01+
+read with bank-$00 addressing (0 hits across the corpus at the flip).
+The old `.rodata`-in-bank-$01+ and `string.N` spill heuristics in
+`symmap.py` are retired — that placement is the intent now.
 
-- **a wla-dx change** — `SUPERFREE` searches banks ascending, so bank
-  $00 wins by construction. A search-order flag (or reversing it for
-  data sections) would flip the default with no per-project setup. This
-  is the clean answer and the only one that needs no knowledge of the
-  ROM layout at compile time. `compiler/wla-dx` currently carries **0
-  local patches**, so this is a deliberate fork decision, not a drive-by;
-- **or a generated per-layout macro** — QBE cannot emit `BANKS <list>`
-  because it does not know the bank count, and the list can be neither
-  a `.DEFINE` nor over-range. `make/common.mk` already generates
-  `project_config.inc`; it could generate the section-declaration macro
-  with a literal list matching the memory map in use. Workable, but it
-  moves ROM-layout knowledge into the build system.
+HiROM, which broke in the 2026-07 experiment, needed two things: `.BASE
+$C0` on every HiROM unit (`memmap_hirom.inc`, `hdr_hirom.asm`) so a label
+at offset $0000 of linker bank *n* is addressed at `$Cn:0000` — the only
+mapping of that half — and a wlalink patch so `.BASE` does not leak into
+RAMSECTION labels (`$7E` + `$C0` was out of 24-bit range; `$7E` + `$80`
+under FastROM silently gave `$FE`). `compiler/wla-dx` therefore carries
+**1 local patch** (`opensnes/ram-labels-ignore-base`, see
+`compiler/PINS.md`). `symmap.py` and `check_bank_reads.py` fold the
+`$C0`/`$80` window back to the linker bank when they read a `.sym`.
 
-The 2026-05-14 attempt (`.SECTION X BANK 1 FREE` in qbe `emitdat`) failed
-for a different reason — a single hardcoded bank, which the audio
-examples fill with sample data. `SEMISUPERFREE`'s fallback list is what
-that attempt was missing.
+Corpus effect: the bank-$00 minimum went from **12 bytes** (tetris,
+likemario, mapandobjects) to **2168** (mode5_hires); the 2026-07 note's
+"honest ceiling" — hand-written asm payload such as tetris's `data.asm`
+strings or snesmod's driver — is what remains in bank $00 by choice.
+Tightening `BANK0_FAIL_THRESHOLD` from 8 is now possible and is the
+deliberate audit step below, not part of the flip.
 
 ## When to bump `BANK0_FAIL_THRESHOLD` tighter
 

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES (full history)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # need full history for the range walk
 
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run lint_asm.py
         # Hand-written ASM in lib/source and templates must declare the
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run check_doc_drift.py
         # Anchored claims that drift behind code: version macros in
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run test_check_nmi_wram_race.py
         # Regression suite for devtools/check_nmi_wram_race.py — the
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run test_symmap.py
         # Regression suite for devtools/symmap/symmap.py --check-overlap, the
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run check_vram_layout.py
         # BG/sprite VRAM bases are programmed through registers that store only
@@ -163,7 +163,7 @@ jobs:
       - name: Check out OpenSNES (with submodules)
         # `make tools` runs the top-level verify-toolchain dependency, which
         # needs the compiler submodules checked out.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -184,7 +184,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Doxygen 1.16.1 (pinned — must match deploy_docs.yml)
         # ubuntu's Doxygen 1.9.8 has a severe Markdown bug; the guard must test

--- a/.github/workflows/msys2_cproc_diagnostic.yml
+++ b/.github/workflows/msys2_cproc_diagnostic.yml
@@ -39,7 +39,7 @@ jobs:
             git
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -182,7 +182,7 @@ jobs:
           ls -la diag_output/ 2>/dev/null || echo "(empty)"
 
       - name: Upload diagnostics
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: msys2-cproc-diagnostics

--- a/.github/workflows/msys2_cproc_diagnostic.yml
+++ b/.github/workflows/msys2_cproc_diagnostic.yml
@@ -182,7 +182,7 @@ jobs:
           ls -la diag_output/ 2>/dev/null || echo "(empty)"
 
       - name: Upload diagnostics
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: msys2-cproc-diagnostics

--- a/.github/workflows/opensnes_build.yml
+++ b/.github/workflows/opensnes_build.yml
@@ -89,7 +89,7 @@ jobs:
       # Checkout the project                 #
       # ------------------------------------ #
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -99,7 +99,7 @@ jobs:
       # each build (~20-30s/leg; the rest — lib+examples+docs+zip — still runs).
       - name: Restore prebuilt toolchain
         id: toolchain
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             bin
@@ -180,7 +180,7 @@ jobs:
       # `make release`, so a failed build never poisons the cache).
       - name: Save prebuilt toolchain (cache miss only)
         if: steps.toolchain.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             bin
@@ -281,7 +281,7 @@ jobs:
       # Upload SDK release                   #
       # ------------------------------------ #
       - name: Upload OpenSNES SDK release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: OpenSNES SDK (${{ matrix.name }}_${{ matrix.arch }})
           path: release/opensnes_${{ matrix.name }}_${{ matrix.arch }}.zip
@@ -290,7 +290,7 @@ jobs:
       # Upload build logs                    #
       # ------------------------------------ #
       - name: Upload build logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: OpenSNES Logs (${{ matrix.name }})
@@ -321,7 +321,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out OpenSNES (with submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -333,7 +333,7 @@ jobs:
       # toolchain build).
       - name: Restore prebuilt toolchain
         id: toolchain
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             bin
@@ -362,7 +362,7 @@ jobs:
 
       - name: Save prebuilt toolchain (cache miss only)
         if: steps.toolchain.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             bin
@@ -453,7 +453,7 @@ jobs:
 
       - name: Upload luna artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: luna-test artifacts
           path: |

--- a/.github/workflows/opensnes_build.yml
+++ b/.github/workflows/opensnes_build.yml
@@ -281,7 +281,7 @@ jobs:
       # Upload SDK release                   #
       # ------------------------------------ #
       - name: Upload OpenSNES SDK release
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: OpenSNES SDK (${{ matrix.name }}_${{ matrix.arch }})
           path: release/opensnes_${{ matrix.name }}_${{ matrix.arch }}.zip
@@ -290,7 +290,7 @@ jobs:
       # Upload build logs                    #
       # ------------------------------------ #
       - name: Upload build logs
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: OpenSNES Logs (${{ matrix.name }})
@@ -453,7 +453,7 @@ jobs:
 
       - name: Upload luna artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: luna-test artifacts
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
       # Upload zip as artifact for release   #
       # ------------------------------------ #
       - name: Upload release zip
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: opensnes-${{ steps.version.outputs.tag }}-${{ matrix.name }}-${{ matrix.arch }}
           path: release/opensnes_${{ steps.version.outputs.tag }}_${{ matrix.name }}_${{ matrix.arch }}.zip
@@ -231,7 +231,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download all release artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # need full history to walk merge-base
 
@@ -94,7 +94,7 @@ jobs:
       # Checkout the project                 #
       # ------------------------------------ #
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -104,7 +104,7 @@ jobs:
       # seeds it. See opensnes_build.yml for the full rationale.
       - name: Restore prebuilt toolchain
         id: toolchain
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             bin
@@ -163,7 +163,7 @@ jobs:
 
       - name: Save prebuilt toolchain (cache miss only)
         if: steps.toolchain.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             bin
@@ -215,7 +215,7 @@ jobs:
       # Upload zip as artifact for release   #
       # ------------------------------------ #
       - name: Upload release zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: opensnes-${{ steps.version.outputs.tag }}-${{ matrix.name }}-${{ matrix.arch }}
           path: release/opensnes_${{ steps.version.outputs.tag }}_${{ matrix.name }}_${{ matrix.arch }}.zip
@@ -228,10 +228,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out OpenSNES
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 
@@ -279,7 +279,7 @@ jobs:
           NOTESEOF
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.version }}
           name: OpenSNES ${{ steps.tag.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 All notable changes to OpenSNES are documented in this file.
 
+## [0.41.0] — 2026-09-07
+
+The placement release: C const data leaves bank $00 by default, HiROM is
+addressed in its full 64 KB view, and the linker fork gets its first
+patch to make that correct. Plus a bench that finally measures the
+const-path gains, and a CI moved to Node 24.
+
+### Added
+- feat(compiler): **C const data is placed in the memory map's asset
+  banks by default** (#127.3, closes #127). QBE emits every `.rodata.N`
+  as `SEMISUPERFREE BANKS ASSET_BANKS` — the directive `ASSET_SECTION`
+  already used — so `static const` tables, string literals and const
+  structs land in the asset banks (highest first) and bank $00 keeps the
+  code. Safe because every C read of const data is a far read (#121),
+  every lib call carries a far pointer (A6), and `check_bank_reads.py`
+  fails the link on a bank-$01+ symbol read with bank-$00 addressing (0
+  hits across the corpus). Bank $00 minimum went from 12 bytes to 71 on
+  the code-heavy games, which now spill code (not data) into bank $01+
+  the way `jsl` allows. Visual regression 85/85 identical.
+- test(devtools): `benchrom` gains seven const-path workloads (animTick,
+  animTickMeta, const pointer walks, const→RAM copy, const struct
+  fields, `tab[i]`), the instrument the A9 optimiser change lacked:
+  v0.39.0 → v0.40.0 measured −9 % to −54 % per call. The runner reads
+  every result from one luna run instead of one per symbol.
+
+### Fixed
+- fix(build): **HiROM addressed in its full view.** Every HiROM unit now
+  carries `.BASE $C0`, so a label at offset $0000 of linker bank *n* is
+  addressed at `$Cn:0000` — the only mapping of that half. Until now the
+  runtime's `.mul32`/`.div32` sat at `07:0000`, a WRAM mirror: any HiROM
+  C program doing 32-bit arithmetic would have crashed, and the 2026-07
+  attempt at #127.3 corrupted HiROM for the same reason.
+- fix(compiler): **wla-dx fork, first local patch** — `.BASE` no longer
+  applies to RAMSECTION labels (`$7E + $C0` was out of 24-bit range;
+  `$7E + $80` under FastROM silently gave `$FE`). `symmap.py` and
+  `check_bank_reads.py` fold the `$C0`/`$80` window back to the linker
+  bank; the `.sym` prints one valid CPU address per line, which luna
+  needs.
+- fix(lib): `consoleNocashMessage` read its string through a 16-bit
+  bank-$00 pointer (pre-A6); it goes through the 24-bit pointer now.
+  Caught by the `debug_channel` runtime fixture the moment string
+  literals moved.
+- ci: the workflows' actions run on Node 24 (checkout v5, cache v5,
+  upload-artifact v6, download-artifact v7, action-gh-release v3); the
+  deprecation notices are gone.
+
+### Changed
+- docs(docs): `KNOWN_LIMITATIONS.md` bank-$00 ROM entry rewritten (code
+  only; the one bank-blind path left is an explicit cast that drops
+  `const`, guarded at link time); `.claude/rules/bank0_budget.md` records
+  the shipped default and retires the "what still blocks it" section;
+  `templates/assets.inc` HiROM caveat resolved; the two open hardware
+  claims (HDMA mid-frame enable, INIDISP at power-on) are arbitrated
+  against the SNES corpus and cited in `hdma.asm` / `crt0.asm`.
+
 ## [0.40.0] — 2026-09-07
 
 The optimiser release: const and far accesses were pinned in QBE's

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -62,38 +62,45 @@ where the actual risk lives. Bypass for a single build with
 `SKIP_NMI_RACE_CHECK=1`. Regression suite:
 `python3 devtools/test_check_nmi_wram_race.py` (6 cases).
 
-### 🟢 Bank $00 ROM overflow → garbage const reads **when dereferenced in C** (caught at link time)
-The limit is narrower than it looks. `static const` arrays each get a SUPERFREE
-section; if bank $00's 32 KB ROM area fills, new const sections spill to bank
-$01+. What breaks depends on **how you read the data**:
+### 🟢 Bank $00 ROM: code only — C const data lives in the asset banks (since #127.3)
+`static const` arrays, string literals and initialised const structs are
+emitted as `.SECTION ".rodata.N" SEMISUPERFREE BANKS ASSET_BANKS`: the
+linker places them in the memory map's asset banks (highest first) and
+bank $00 keeps the code. This is safe because every way C reaches const
+data carries the bank:
 
-- **Passed to a lib DMA/asset function — works in ANY bank.** `dmaCopyVram`,
+- **Passed to a lib DMA/asset function — any bank.** `dmaCopyVram`,
   `dmaCopyCGram`, `dmaCopyVramMode7`, `LzssDecodeVram`, `mapLoad`, etc. take a
-  4-byte pointer whose high byte carries the real bank, and the asm reads it
-  (`dmaCopyVram` does `lda 11,s → sta.l $4304`, the DMA source-bank register). So
-  tiles / palettes / maps / fonts can live in any bank — this is the common case.
-- **Dereferenced directly in C (`ptr[i]`, `*ptr`) — bank $00 only.** The compiler
-  still emits `lda.l $XXXX,x` (implicit bank $00) for a C deref, so a `static
-  const` array you index in C must fit bank $00 or it returns garbage. (This is
-  the remaining half of chantier A6.)
+  4-byte pointer whose high byte is the real bank, and the asm reads it
+  (`dmaCopyVram` does `lda 11,s → sta.l $4304`, the DMA source-bank register).
+- **Dereferenced in C (`tab[i]`, `*p`, `p->field`) — any bank.** A read
+  through a `const` pointee is compiled with far addressing since #121:
+  `lda.l sym`, `lda.l sym,x` or `[tcc__r9]`.
+- **The one bank-blind path left:** casting the `const` away and reading
+  through a plain pointer (`*(u8 *)tab`) — the compiler then emits the
+  bank-$00-implicit `lda.l $0000,x`. `devtools/check_bank_reads.py` runs
+  at every link and fails on a symbol in bank $01+ read with bank-$00
+  addressing, so this cannot ship silently.
 
-**Mitigation (active since P1.5, extended 2026-07-07):** `make/common.mk` runs
-`devtools/symmap/symmap.py --check-bank0-overflow` after every link. Any C
-const data spilled to bank $01+ fails the build with a "Bank $00 ROM
-overflow" message naming the symbols — both string literals and named
-`static const` data (the checker reads the linker's `.rodata.N` sections, so
-top-level statics without a `.N` symbol suffix are covered too; harmless
-`__opensnes_force_emit_*` anchors are exempt). Tight free-space (< 2 KB)
-prints a soft warning. Set `SKIP_BANK0_CHECK=1` to bypass for debugging.
+HiROM: every HiROM unit carries `.BASE $C0` so a datum at offset $0000 of
+a high bank is addressed in the full 64 KB view (`$Cn:0000`); the wlalink
+fork keeps that base off RAMSECTION labels.
 
-If you hit this:
-- **Prefer the DMA path:** keep big assets `const` and feed them to the lib's
-  DMA/asset functions — they already work from any bank (see above). For a
-  runtime-computed bank, the explicit `dmaCopyVramBank(src, bank, …)` /
+**What the ratchet still guards:** bank $00 free space. `make/common.mk`
+runs `devtools/symmap/symmap.py --check-bank0-overflow` after every link:
+free space below `BANK0_FAIL_THRESHOLD` fails the build, below 2 KB
+prints a soft warning, and every link prints how much declared payload
+sits in bank $00. Set `SKIP_BANK0_CHECK=1` to bypass for debugging. Corpus
+minimum at the flip: 2168 bytes (was 12).
+
+If bank $00 still runs out (code plus hand-written asm payload):
+- Declare `.incbin` / `.db` payload with `ASSET_SECTION` (`templates/assets.inc`)
+  instead of a bank-$00 `.SECTION` — it takes the same asset banks the
+  compiler uses.
+- For a runtime-computed bank, the explicit `dmaCopyVramBank(src, bank, …)` /
   `dmaCopyCGramBank(src, bank, …)` variants take the bank as a parameter.
-- Combine related const arrays read in C into one array + offset macros.
-- Move large C-dereferenced const data to RAM (drop the `const`).
-- Use assembly with explicit bank addressing for very large blobs.
+- Read `symmap.py --check-bank0-overflow game.sym`: it lists the largest
+  bank-$00 sections.
 
 ### 🟡 BG1 scroll and Mode 7 matrix share one write-twice latch
 `$210D`/`$210E` are dual registers (BG1 scroll in modes 0-6, Mode 7 scroll

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ and **what is next**.
 
 ---
 
-## Current Status: post-v0.40.0
+## Current Status: post-v0.41.0
 
 A modern, well-tested SNES SDK ready for serious hobby development, game jams,
 and educational use, building toward commercial-grade maturity. The compiler

--- a/compiler/PINS.md
+++ b/compiler/PINS.md
@@ -30,8 +30,8 @@ reformat without updating the script.
 | path | sha | source |
 |------|-----|--------|
 | compiler/cproc | 6d3953d27b0da0e5aa48af9e0d91f00fa829373a | github.com/k0b3n4irb/cproc:feat/b2-far-qualifier |
-| compiler/qbe | 852cea43c4c78ed15775bc838d00beb8ddb55429 | github.com/k0b3n4irb/qbe:feat/b2-far-qualifier |
-| compiler/wla-dx | 91c52b1f4ef3cc8ba3c0638f7536539579af6a9f | github.com/k0b3n4irb/wla-dx v10.7 (release tag) |
+| compiler/qbe | ca50db8ae000a28e80d8b6202cc65c9ff9ff53b9 | github.com/k0b3n4irb/qbe:feat/b2-far-qualifier |
+| compiler/wla-dx | 86df3317f3ba40c7815d358160e06188d2011e7c | github.com/k0b3n4irb/wla-dx:opensnes/ram-labels-ignore-base (v10.7 + 1) |
 <!-- END PINS -->
 
 ## Local patches carried on top of upstream
@@ -68,11 +68,12 @@ own structural defect is tracked as A6 in the structural-defects catalogue;
 reducing pointer storage cascades through QBE w65816's indirect-call emit
 pass). Empirically validated against the full quick test suite.
 
-### compiler/qbe — 55 patches (the bulk of the SDK's compiler magic)
+### compiler/qbe — 56 patches (the bulk of the SDK's compiler magic)
 
 Selected highlights (full list via `git -C compiler/qbe log HEAD --not upstream/master --oneline`):
 
 ```
+ca50db8 Place C const data in the memory map's asset banks by default (chantier #127.3)
 852cea4 Only the volatile bit pins loads in loadopt / promote / gcm (chantier A9)
 7118e4c w65816: bank-honouring codegen for far RAM (chantier B2, Phase 2)
 80eaea2 Accept the `farram` access flag and section ".far" data (chantier B2, Phase 1)
@@ -104,7 +105,18 @@ These commits implement the cycle reductions documented in
 `~/.claude/.../memory/compiler_optimizations.md` (Phases 1 through 7a, total
 −22% vs PVSnesLib baseline). Lose them and benchmarks regress.
 
-### compiler/wla-dx — 0 patches ahead; pinned to the **v10.7 release**
+### compiler/wla-dx — 1 patch ahead of the **v10.7 release** (chantier #127.3, 2026-09-07)
+
+```
+86df331 wlalink: .BASE does not apply to RAMSECTION labels on the 65816
+```
+
+The first local patch on this fork, a deliberate decision (see
+`.claude/rules/bank0_budget.md`): HiROM needs `.BASE $C0` on every unit
+so data at offset $0000 of a high linker bank is addressed in the full
+64 KB view, and upstream adds the base to WRAM labels too ($7E → $13E).
+
+### compiler/wla-dx — previously: pinned to the **v10.7 release**
 
 The submodule HEAD is the `v10.7` release tag (`91c52b1f`), which our
 fork mirrors from upstream. Zero local patches.

--- a/devtools/benchrom/Makefile
+++ b/devtools/benchrom/Makefile
@@ -4,7 +4,7 @@ TARGET   := benchrom.sfc
 ROM_NAME := BENCHROM
 
 USE_LIB  := 1
-LIB_MODULES := console mode7 map sprite sprite_dynamic sprite_lut dma
+LIB_MODULES := console mode7 map sprite sprite_dynamic sprite_lut dma anim
 
 CSRC   := main.c
 ASMSRC := data.asm

--- a/devtools/benchrom/bench.py
+++ b/devtools/benchrom/bench.py
@@ -41,12 +41,37 @@ RESULTS = [
     ("r_sd_draw_rf",   "refresh+draw+EndFrame+flush"),
     ("r_sd_flush_idle", "NmiFlush (idle floor)"),
     ("r_sd_draw_c",    "C-model draw+EndFrame"),
+    # const paths — the A9 instrument (reads through `const` pointers/tables;
+    # per CALL of the loop body: animTick, or a 32-element walk/copy)
+    ("r_c_anim_tick",  "animTick (const clip)"),
+    ("r_c_anim_meta",  "animTickMeta (+const table)"),
+    ("r_c_walk8",      "const u8 walk x32", 8),
+    ("r_c_walk16",     "const u16 walk x32", 8),
+    ("r_c_copy",       "const->RAM copy x32", 8),
+    ("r_c_fields",     "const struct fields"),
+    ("r_c_index",      "const tab[i] (fused)"),
 ]
 
 
+_cache: dict[str, int] = {}
+
+
 def peek16(luna, sym):
-    b = probelib.peek(luna, ROM, STEPS, sym, 2)
-    return b[0] | (b[1] << 8)
+    """All results in ONE luna run (one --peek per symbol): a run is 200 M
+    steps, so one per symbol made the table take a quarter of an hour."""
+    if not _cache:
+        import json
+        import subprocess
+        syms = ["r_bench_done", "r_cal_empty", "r_c_val"] + [r[0] for r in RESULTS]
+        cmd = [luna, "state", "-n", str(STEPS), "--out", "-"]
+        for s in syms:
+            cmd += ["--peek", f"{s}:2"]
+        cmd.append(str(ROM))
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=1200).stdout
+        for p in json.loads(out)["peeks"]:
+            b = bytes.fromhex(p["bytes_hex"])
+            _cache[p["spec"].split(":")[0]] = b[0] | (b[1] << 8)
+    return _cache[sym]
 
 
 def main() -> int:
@@ -58,14 +83,20 @@ def main() -> int:
     if done != 0xBEEF:
         print(f"FAIL: fixture incomplete (r_bench_done={done:#x}) — raise STEPS?")
         return 1
+    val = peek16(luna, "r_c_val")
+    if val != 528:
+        print(f"FAIL: const-path correctness (r_c_val={val}, expected 528)")
+        return 1
     cal = peek16(luna, "r_cal_empty")
     cal_cyc = cal * CYCLES_PER_FRAME / N_ITER
     print(f"calibration: {cal} frames ({cal_cyc:.1f} cyc/iter loop overhead)\n")
-    print(f"{'function':<18} {'frames':>6} {'~cycles/call':>12}")
-    for sym, name in RESULTS:
+    print(f"{'function':<28} {'frames':>6} {'~cycles/call':>12}")
+    for row in RESULTS:
+        sym, name = row[0], row[1]
+        div = row[2] if len(row) > 2 else 1      # loops run N_ITER/div times
         f = peek16(luna, sym)
-        cyc = (f - cal) * CYCLES_PER_FRAME / N_ITER
-        print(f"{name:<18} {f:>6} {cyc:>12.0f}")
+        cyc = (f - cal / div) * CYCLES_PER_FRAME / (N_ITER / div)
+        print(f"{name:<28} {f:>6} {cyc:>12.0f}")
     return 0
 
 

--- a/devtools/benchrom/main.c
+++ b/devtools/benchrom/main.c
@@ -21,6 +21,7 @@
 #include <snes/mode7.h>
 #include <snes/map.h>
 #include <snes/sprite.h>
+#include <snes/anim.h>
 
 /* Iterations per measured function. Chosen so cheap fns still span
  * >= ~20 frames (quantization < 5 %). volatile so the loop counter
@@ -62,9 +63,26 @@ u16 r_sd_draw;       /* draw+EndFrame pair, oamrefresh=0 (steady
 u16 r_sd_draw_rf;    /* refresh+draw+EndFrame+flush (full lifecycle)*/
 u16 r_sd_flush_idle; /* NmiFlush with empty queue (per-frame floor) */
 u16 r_sd_draw_c;     /* C model of the steady 16Draw + ASM EndFrame  */
+
+/* const-path measurement points (chantier A9, 2026-09-07). Every one of
+ * these reads ROM through a `const` pointer or a const table: exactly the
+ * accesses QBE's optimiser used to pin as if volatile (never forwarded,
+ * never promoted out of their alloca). benchrom's other functions are
+ * ASM paths and cannot see that class; these are its instrument. Each
+ * loop body is a small non-inlined function so the frame stays under
+ * 256 bytes (large-frame [tcc__fp],y addressing would dominate). */
+u16 r_c_anim_tick;   /* animTick(): lib anim, clip/frames/durations walk  */
+u16 r_c_anim_meta;   /* animTickMeta(): + const pointer table indexed     */
+u16 r_c_walk8;       /* sum of 32 bytes through `const u8 *p++`           */
+u16 r_c_walk16;      /* sum of 32 words through `const u16 *p++`          */
+u16 r_c_copy;        /* 32-byte `*dest++ = *src++`, const src (mycopy)    */
+u16 r_c_fields;      /* const struct fields through `const Rec *r`        */
+u16 r_c_index;       /* tab[i] on a const table (indexed-long fusion)     */
+u16 r_c_val;         /* correctness: walk8 sum (528) | walk16 sum & 0xFF  */
 u16 r_bench_done;    /* 0xBEEF when every result above is written  */
 
 static volatile u16 vi;   /* opaque loop bound (defeats folding) */
+static volatile u16 vc;   /* N_ITER/8 for the 32-element const walks   */
 
 /* --- C-port probe: far-access mapGetMetaTile model --- */
 extern u16 mapadrrowlut[];        /* $7E RAMSECTION (map.asm) */
@@ -122,6 +140,30 @@ static u16 c_getmetatile(u16 x, u16 y) {
     u16 off = lutp[((y >> 2) & 0xFFFE) >> 1] + ((x >> 2) & 0xFFFE);
     return *(const u16 *)(mapp + off) & 0x03FF;
 }
+
+/* --- const-path workloads (A9 instrument) --- */
+typedef struct { u8 a; u8 b; u16 w; u32 l; } CRec;
+static const u8  c_tab8[32]  = { 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,
+                                 17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 };
+static const u16 c_tab16[32] = { 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,
+                                 17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 };
+static const CRec c_recs[8] = {
+    {1,2,300,40000UL},{3,4,500,60000UL},{5,6,700,80000UL},{7,8,900,100000UL},
+    {9,10,1100,120000UL},{11,12,1300,140000UL},{13,14,1500,160000UL},{15,16,1700,180000UL} };
+static const u16 c_frames[8] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+static const u8  c_durs[8]   = { 1, 2, 1, 3, 1, 2, 1, 1 };
+static const AnimClip c_clip = { c_frames, c_durs, 8, 1, ANIM_LOOP, 0 };
+static const u16 *const c_meta[8] = { c_tab16, c_tab16+1, c_tab16+2, c_tab16+3,
+                                      c_tab16+4, c_tab16+5, c_tab16+6, c_tab16+7 };
+static AnimPlayer c_player = ANIM_PLAYER_INIT;
+static u8 c_dst[32];
+static volatile u8 c_n;          /* opaque inner bound (32) */
+
+u16 c_walk8(void)  { const u8 *p = c_tab8;  u16 s = 0; u8 k, n = c_n; for (k = 0; k < n; k++) s += *p++; return s; }
+u16 c_walk16(void) { const u16 *p = c_tab16; u16 s = 0; u8 k, n = c_n; for (k = 0; k < n; k++) s += *p++; return s; }
+void c_copy(void)  { u8 *d = c_dst; const u8 *p = c_tab8; u8 k, n = c_n; for (k = 0; k < n; k++) *d++ = *p++; }
+u16 c_fields(u8 i) { const CRec *r = &c_recs[i & 7]; return (u16)(r->a + r->b + r->w + (u16)r->l); }
+u16 c_index(u8 i)  { return (u16)(c_tab8[i & 31] + c_tab16[i & 31]); }
 
 /* Frame bracket helpers */
 static u16 t0;
@@ -275,6 +317,54 @@ int main(void) {
         oamInitDynamicSpriteEndFrame();
     }
     r_sd_draw_c = bench_end();
+
+    /* --- const paths (A9 instrument) --- */
+    c_n = 32;
+    vc = N_ITER / 8;
+    animPlay(&c_player, &c_clip);
+    bench_begin();
+    for (i = 0; i < vi; i++) {
+        animTick(&c_player);
+    }
+    r_c_anim_tick = bench_end();
+
+    bench_begin();
+    for (i = 0; i < vi; i++) {
+        c_dst[0] = (u8)*animTickMeta(&c_player, c_meta);
+    }
+    r_c_anim_meta = bench_end();
+
+    bench_begin();
+    for (i = 0; i < vc; i++) {
+        c_walk8();
+    }
+    r_c_walk8 = bench_end();
+
+    bench_begin();
+    for (i = 0; i < vc; i++) {
+        c_walk16();
+    }
+    r_c_walk16 = bench_end();
+
+    bench_begin();
+    for (i = 0; i < vc; i++) {
+        c_copy();
+    }
+    r_c_copy = bench_end();
+
+    bench_begin();
+    for (i = 0; i < vi; i++) {
+        c_fields((u8)i);
+    }
+    r_c_fields = bench_end();
+
+    bench_begin();
+    for (i = 0; i < vi; i++) {
+        c_index((u8)i);
+    }
+    r_c_index = bench_end();
+
+    r_c_val = (u16)(c_walk8() | (c_walk16() & 0xFF));   /* 528 | 16 = 528 */
 
     r_bench_done = 0xBEEF;
 

--- a/devtools/check_bank_reads.py
+++ b/devtools/check_bank_reads.py
@@ -47,7 +47,14 @@ def sym_table(sym_path: Path) -> dict[str, tuple[int, int]]:
     for line in sym_path.read_text().splitlines():
         m = re.match(r'^([0-9a-fA-F]{2}):([0-9a-fA-F]{4})\s+(\S+)$', line.strip())
         if m:
-            out[m.group(3)] = (int(m.group(1), 16), int(m.group(2), 16))
+            bank = int(m.group(1), 16)
+            # HiROM units carry .BASE $C0 (FastROM .BASE $80): fold the
+            # CPU-visible ROM window back to the linker bank (#127.3)
+            if 0xC0 <= bank <= 0xFF:
+                bank -= 0xC0
+            elif 0x80 <= bank <= 0xBF:
+                bank -= 0x80
+            out[m.group(3)] = (bank, int(m.group(2), 16))
     return out
 
 

--- a/devtools/compiler-tests/runtime/a6_farptr/main.c
+++ b/devtools/compiler-tests/runtime/a6_farptr/main.c
@@ -19,7 +19,10 @@
 #include <snes.h>
 
 extern const u8 a6_sentinel[];                                /* BANK 2 */
-const u8 s0[8] = {0xA0,0xA1,0xA2,0xA3,0xA4,0xA5,0xA6,0xA7};   /* bank $00 */
+/* The bank-0 control is a MUTABLE initialised array: since #127.3 a `const`
+ * one is placed in the asset banks (this very object moved to 07:8000 at
+ * the flip and hi0 read 7), so only RAM-backed data is a bank-0 object. */
+u8 s0[8] = {0xA0,0xA1,0xA2,0xA3,0xA4,0xA5,0xA6,0xA7};         /* bank $00 (WRAM) */
 
 volatile const u8 *p2;
 volatile const u8 *p0;

--- a/devtools/symmap/symmap.py
+++ b/devtools/symmap/symmap.py
@@ -103,6 +103,20 @@ class Overlap:
         return self.overlap_end - self.overlap_start + 1
 
 
+def rom_bank(bank: int) -> int:
+    """Fold a CPU-visible ROM bank byte back to the linker bank.
+
+    Since #127.3 the HiROM units carry `.BASE $C0` (and FastROM builds
+    `.BASE $80`), so the .sym prints ROM labels/sections as c0:8644 /
+    80:8644 while the linker bank is 0. WRAM banks ($7E/$7F, and the
+    bank-0 mirror) never carry a base and pass through unchanged."""
+    if 0xC0 <= bank <= 0xFF:
+        return bank - 0xC0
+    if 0x80 <= bank <= 0xBF:
+        return bank - 0x80
+    return bank
+
+
 class SymbolTable:
     """Parser and analyzer for WLA-DX .sym files"""
 
@@ -143,7 +157,7 @@ class SymbolTable:
                     if m:
                         self.sections.append(SectionRec(
                             name=m.group(4),
-                            bank=int(m.group(1), 16),
+                            bank=rom_bank(int(m.group(1), 16)),
                             address=int(m.group(2), 16),
                             size=int(m.group(3), 16)))
                     continue
@@ -159,7 +173,7 @@ class SymbolTable:
                     if m:
                         self.ramsections.append(SectionRec(
                             name=m.group(5),
-                            bank=int(m.group(1), 16),
+                            bank=rom_bank(int(m.group(1), 16)),
                             address=int(m.group(3), 16),
                             size=int(m.group(4), 16)))
                     continue
@@ -169,7 +183,7 @@ class SymbolTable:
                 match = re.match(r'^([0-9a-fA-F]{2}):([0-9a-fA-F]{4})\s+(\S+)$', line)
                 if match:
                     bank_str, addr_str, name = match.groups()
-                    bank = int(bank_str, 16)
+                    bank = rom_bank(int(bank_str, 16))
                     address = int(addr_str, 16)
                     full_addr = (bank << 16) | address
                 else:
@@ -369,38 +383,16 @@ class SymbolTable:
         critical = []
         warnings = []
 
-        # Check all banks > $00 for C-generated DATA symbols
-        for bank, symbols in self.banks.items():
-            if bank == 0x00:
-                continue
-            for sym in symbols:
-                if sym.address < 0x8000:
-                    continue
-                if re.match(r'^(?:\w+_)?string\.\d+$', sym.name):
-                    critical.append(sym)
-                elif self._is_c_generated_data(sym):
-                    warnings.append(sym)
-
-        # QBE emits every C const datum into a ".rodata.N" SUPERFREE section.
-        # Any such section landing in bank $01+ is read as garbage by the
-        # 16-bit C deref — UNLESS it only holds __opensnes_force_emit_*
-        # anchors, which exist for the linker and are never read.
-        # Caught 2026-07-07: likemario's anim clips (named top-level statics,
-        # no `.N` suffix, so invisible to the symbol heuristics above)
-        # spilled to bank $02 and shipped a silently dead animation.
-        already = {(s.bank, s.address) for s in critical}
-        for sec in self.sections:
-            if sec.bank == 0x00 or not re.match(r'^\.rodata\.\d+$', sec.name):
-                continue
-            contained = [s for s in self.banks.get(sec.bank, [])
-                         if sec.address <= s.address < sec.address + sec.size
-                         and not s.name.startswith('_sizeof_')]
-            live = [s for s in contained
-                    if not s.name.startswith('__opensnes_force_emit_')]
-            for sym in live:
-                if (sym.bank, sym.address) not in already:
-                    critical.append(sym)
-                    already.add((sym.bank, sym.address))
+        # #127.3 (2026-09-07): C const data is PLACED in bank $01+ on purpose
+        # now — QBE emits `.rodata.N` as SEMISUPERFREE BANKS ASSET_BANKS, and
+        # every C read of const data is a far read (#121), every lib call a
+        # far pointer (A6). A .rodata section or a string literal in a high
+        # bank is therefore the intended layout, not a spill: the old
+        # `string.N` / `.rodata.N`-in-bank-$01+ heuristics are retired. The
+        # read-side guard that still matters — a symbol in bank $01+ read
+        # with bank-$00 addressing — is devtools/check_bank_reads.py, run at
+        # every link. This method keeps its signature for the callers and
+        # reports the bank-$00 free space only.
 
         # Calculate bank $00 ROM free space
         bank0_syms = self.banks.get(0x00, [])
@@ -661,8 +653,8 @@ def print_bank0_overflow_check(table: SymbolTable, warn_threshold: int = 2048,
     if fail_threshold > 0 and free_bytes < fail_threshold:
         print(f"{Colors.RED}{Colors.BOLD}FAIL: Bank $00 ROM imminent overflow "
               f"({free_bytes} bytes free, fail-threshold: {fail_threshold}){Colors.RESET}")
-        print("  One more const literal here will spill to bank $01+ and read")
-        print("  as garbage at runtime (see KNOWN_LIMITATIONS.md, severity 🔴).")
+        print("  The next code section or hand-written bank-$00 payload will not")
+        print("  fit (C const data goes to the asset banks since #127.3).")
         print(f"  See .claude/rules/bank0_budget.md for the refactor playbook.")
         return 1
 
@@ -670,11 +662,12 @@ def print_bank0_overflow_check(table: SymbolTable, warn_threshold: int = 2048,
     if free_bytes < warn_threshold:
         print(f"{Colors.YELLOW}WARNING: Bank $00 ROM nearly full "
               f"({free_bytes} bytes free, threshold: {warn_threshold}){Colors.RESET}")
-        print("  Adding more const data or string literals may cause overflow.")
+        print("  Only code and hand-written bank-$00 payload consume it now")
+        print("  (C const data goes to the asset banks since #127.3).")
         report_bank0_asset_payload(table)
         return 2
 
-    print(f"{Colors.GREEN}OK: No C-generated data in bank $01+ "
+    print(f"{Colors.GREEN}OK: bank $00 ROM (code) "
           f"(bank $00 ROM free: {free_bytes} bytes){Colors.RESET}")
     report_bank0_asset_payload(table)
     return 0

--- a/lib/include/snes.h
+++ b/lib/include/snes.h
@@ -55,13 +55,13 @@
 #define OPENSNES_VERSION_MAJOR 0
 
 /** @brief OpenSNES minor version */
-#define OPENSNES_VERSION_MINOR 40
+#define OPENSNES_VERSION_MINOR 41
 
 /** @brief OpenSNES patch version */
 #define OPENSNES_VERSION_PATCH 0
 
 /** @brief OpenSNES version string */
-#define OPENSNES_VERSION_STRING "0.40.0"
+#define OPENSNES_VERSION_STRING "0.41.0"
 
 /*============================================================================
  * Core Headers

--- a/lib/source/debug.asm
+++ b/lib/source/debug.asm
@@ -56,14 +56,17 @@ consoleMesenBreakpoint:
 ; Write a null-terminated string to the Nocash debug port ($21FC).
 ; Each byte is written individually; the null terminator is NOT sent.
 ;
-; Stack layout (after PHP/PHB):
+;Stack layout (after PHP/PHB):
 ;   1,s   = P (processor status, from PHP)
 ;   2,s   = B (data bank, from PHB)
 ;   3-5,s = return address (3 bytes from JSL)
-;   6-7,s = msg pointer (16-bit, Bank $00)
+;   6-7,s = msg pointer low 16 bits
+;   8,s   = msg pointer bank byte (post-A6 4-byte pointer)
 ;
-; The message pointer is in Bank $00 (C compiler generates Bank $00 addresses).
-; We use long addressing with Bank $00 to read the string bytes.
+; The string is read through a 24-bit pointer: since #127.3 string
+; literals live in the asset banks (bank $07 on a LoROM map), and the old
+; `lda.l $000000,x` bank-$00 read returned garbage — caught by the
+; debug_channel runtime fixture at the flip.
 ;------------------------------------------------------------------------------
 consoleNocashMessage:
     php
@@ -73,17 +76,21 @@ consoleNocashMessage:
     .ACCU 16
     .INDEX 16
 
-    lda 6,s                     ; msg pointer (16-bit address in Bank $00)
-    tax                         ; X = current character pointer
+    lda 6,s                     ; msg pointer low 16
+    sta.b tcc__r0
+    lda 8,s                     ; msg pointer bank byte (high byte = pad)
+    and #$00FF
+    sta.b tcc__r0+2
+    ldy #0
 
     sep #$20                    ; 8-bit A for character reads
     .ACCU 8
 
 @loop:
-    lda.l $000000,x             ; read byte from Bank $00 + X
+    lda [tcc__r0],y             ; read byte through the 24-bit pointer
     beq @done                   ; null terminator? stop
     sta.l REG_DEBUG             ; write character to debug port
-    inx
+    iny
     bra @loop
 
 @done:

--- a/lib/source/hdma.asm
+++ b/lib/source/hdma.asm
@@ -134,9 +134,17 @@ hdmaSetup:
     ; the real first entry instead: a mid-frame hdmaEnable() starts the table
     ; one line late and clean, whatever the boot timing or DP residue.
     ; Observed with luna on hdma/gradient_colors (CGRAM entry 1 clobbered)
-    ; and hdma/hdma_helpers (BG1HOFS left at a stale value); the HBlank
-    ; procedure (decrement, reload on zero) is anomie's — to verify against
-    ; the SNES corpus (cartouche was unreachable when this landed).
+    ; and hdma/hdma_helpers (BG1HOFS left at a stale value). Arbitrated
+    ; against the SNES corpus (Cartouche, 2026-09-07): anomie-regs marks
+    ; Address ($43x8-9) and Line Counter ($43xA) as "required if HDMA is to
+    ; be started mid-frame" — "you must basically do the init process
+    ; manually by setting $43x8-A"; the snesdev VBlank-routine page states
+    ; the symptom ("enabling a HDMA channel too late will not reset the
+    ; HDMA table position and cause invalid values to be written to the
+    ; target register"); the per-scanline order (decrement $43xA, reload
+    ; the entry when it reaches zero) is in the sfc-dev-wiki register
+    ; explanations. Sources: romhacking.net/documents/196,
+    ; snes.nesdev.org/wiki/VBlank_routine, wiki.superfamicom.org/registers.
     lda #1
     sta.l $000A,x           ; $43xA = NTRL: reload the first entry at the next HBlank
 
@@ -222,9 +230,17 @@ hdmaSetupBank:
     ; the real first entry instead: a mid-frame hdmaEnable() starts the table
     ; one line late and clean, whatever the boot timing or DP residue.
     ; Observed with luna on hdma/gradient_colors (CGRAM entry 1 clobbered)
-    ; and hdma/hdma_helpers (BG1HOFS left at a stale value); the HBlank
-    ; procedure (decrement, reload on zero) is anomie's — to verify against
-    ; the SNES corpus (cartouche was unreachable when this landed).
+    ; and hdma/hdma_helpers (BG1HOFS left at a stale value). Arbitrated
+    ; against the SNES corpus (Cartouche, 2026-09-07): anomie-regs marks
+    ; Address ($43x8-9) and Line Counter ($43xA) as "required if HDMA is to
+    ; be started mid-frame" — "you must basically do the init process
+    ; manually by setting $43x8-A"; the snesdev VBlank-routine page states
+    ; the symptom ("enabling a HDMA channel too late will not reset the
+    ; HDMA table position and cause invalid values to be written to the
+    ; target register"); the per-scanline order (decrement $43xA, reload
+    ; the entry when it reaches zero) is in the sfc-dev-wiki register
+    ; explanations. Sources: romhacking.net/documents/196,
+    ; snes.nesdev.org/wiki/VBlank_routine, wiki.superfamicom.org/registers.
     lda #1
     sta.l $000A,x           ; $43xA = NTRL: reload the first entry at the next HBlank
 
@@ -308,9 +324,17 @@ hdmaSetupIndirect:
     ; the real first entry instead: a mid-frame hdmaEnable() starts the table
     ; one line late and clean, whatever the boot timing or DP residue.
     ; Observed with luna on hdma/gradient_colors (CGRAM entry 1 clobbered)
-    ; and hdma/hdma_helpers (BG1HOFS left at a stale value); the HBlank
-    ; procedure (decrement, reload on zero) is anomie's — to verify against
-    ; the SNES corpus (cartouche was unreachable when this landed).
+    ; and hdma/hdma_helpers (BG1HOFS left at a stale value). Arbitrated
+    ; against the SNES corpus (Cartouche, 2026-09-07): anomie-regs marks
+    ; Address ($43x8-9) and Line Counter ($43xA) as "required if HDMA is to
+    ; be started mid-frame" — "you must basically do the init process
+    ; manually by setting $43x8-A"; the snesdev VBlank-routine page states
+    ; the symptom ("enabling a HDMA channel too late will not reset the
+    ; HDMA table position and cause invalid values to be written to the
+    ; target register"); the per-scanline order (decrement $43xA, reload
+    ; the entry when it reaches zero) is in the sfc-dev-wiki register
+    ; explanations. Sources: romhacking.net/documents/196,
+    ; snes.nesdev.org/wiki/VBlank_routine, wiki.superfamicom.org/registers.
     lda #1
     sta.l $000A,x           ; $43xA = NTRL: reload the first entry at the next HBlank
 

--- a/templates/assets.inc
+++ b/templates/assets.inc
@@ -45,17 +45,14 @@
 ; garbage from anywhere else. The build's bank-blind check catches that
 ; case, so if you are unsure: move it out, and let the build tell you.
 ;
-; ## HiROM caveat (untested, latent — see the chantier note)
+; ## HiROM
 ;
-; This macro is verified on LoROM and SA-1. On HiROM the placement below
-; puts payload at offset $0000 in a low-numbered bank, and a HiROM
-; experiment (2026-07-25) showed generic far access — `dmaCopyVram`, a
-; `:sym` far pointer — to that location reading garbage, while a FORCE
-; section at offset $8000 (how snesmod places SOUNDBANK) reads fine. No
-; shipped example uses ASSET_SECTION on HiROM, so this is latent, not a
-; live bug. If you are the first: do NOT trust it on HiROM until
-; `.claude/notes/chantiers/127_rodata_default_placement.md` is resolved —
-; verify the DMA'd bytes with luna, or keep the data in bank $00.
+; Verified on LoROM, SA-1 and HiROM (#127.3, 2026-09-07). HiROM units carry
+; `.BASE $C0` (memmap_hirom.inc) so payload at offset $0000 of a high bank
+; is addressed in the full 64 KB view ($Cn:0000); the wlalink fork keeps
+; that base off RAMSECTION labels. Since #127.3 the compiler places its own
+; const data (`.rodata.N`) with this very directive, so ASSET_SECTION is
+; only needed for hand-written payload (.incbin, .db tables).
 ;----------------------------------------------------------------------
 
 ; SEMISUPERFREE with an explicit bank order: the linker tries 7 first and

--- a/templates/crt0.asm
+++ b/templates/crt0.asm
@@ -504,8 +504,11 @@ FastStart:
     ; 40.9 ms = 2.5 frames, visible on first launch, gone on "reload"
     ; (memory kept). luna zero-fills everything, so it could not show it.
     ; Long addressing: DBR is not set up yet. InitHardware writes $8F
-    ; again; that is fine. Power-on register state is not something to
-    ; rely on (to verify against the SNES corpus for the exact wording).
+    ; again; that is fine. The SNES corpus (Cartouche, 2026-09-07) states
+    ; no guaranteed power-on value for INIDISP; every reference boot
+    ; sequence writes $8F before touching anything else (e.g.
+    ; oldmachines.io/supernintendo/homebrew "from reset to a stable
+    ; frame"), which is what this does.
     lda #$8F
     sta.l $002100       ; INIDISP: forced blank, brightness 15
 

--- a/templates/hdr_hirom.asm
+++ b/templates/hdr_hirom.asm
@@ -101,9 +101,7 @@
 ;------------------------------------------------------------------------------
 
 .BANK 0
-.ifdef FASTROM
-.BASE $80
-.endif
+.BASE $C0                   ; full-view HiROM bank byte, see memmap_hirom.inc
 .ORG 0
 .SECTION ".hirom_reserved" FORCE
     .DSB $8000, $00     ; Fill $0000-$7FFF with zeros (reserved, inaccessible)

--- a/templates/memmap_hirom.inc
+++ b/templates/memmap_hirom.inc
@@ -15,6 +15,16 @@
 .ROMBANKSIZE $10000         ; 64KB per bank (HiROM standard)
 .ROMBANKS 8                 ; Match ROM configuration
 
+; Bank byte of every 24-bit address and `:label` in this unit = $C0 + linker
+; bank (#127.3, 2026-09-07). HiROM maps the FULL 64 KB of each ROM bank only
+; at $C0-$FF; banks $00-$3F / $80-$BF expose the upper half ($8000-$FFFF)
+; alone. Without this base a label at offset $0000 of linker bank 1 became
+; $01:0000 — WRAM mirror, not ROM — which is why the runtime's .mul32/.div32
+; at 07:0000 and any far-placed payload read garbage on HiROM. Code at
+; $8000+ is reachable both ways ($C0:8xxx mirrors $00:8xxx); $C0-$FF is
+; also the FastROM window, so nothing gets slower.
+.BASE $C0
+
 ; Bank search order for bulk read-only payload: highest first, so it lands
 ; away from the code bank. A STRING define — a bare 7-1 would be read as an
 ; expression and BANKS needs the literal text.

--- a/tools/luna-test/baselines/wram.json
+++ b/tools/luna-test/baselines/wram.json
@@ -1,342 +1,342 @@
 {
   "audio_apu_switch": {
     "stream": "fb5b3669410d258a5467d2ede42045da9b95f2af350ee82d0ad8379b222bb694",
-    "rom_sha256": "dbbca8c5a495cc026a3373b8006b3080878980d08c57056cb6941790732fb0d6"
+    "rom_sha256": "d533676dbe67bac6b77275837df51433a1ad9c291b8bcbbe97fa671202dbb599"
   },
   "audio_echo": {
-    "stream": "5477295d8e9198f6a4061e51321d3b3cb627ecd0268fb4036d549936e0810f7f",
-    "rom_sha256": "d8b1e0d4f5e53a995b8296688a71e299fc7d12d2ca834cf956d40fed595c390a"
+    "stream": "6f1a3e9d85e0775fd3430b4d3cc2aa1d060e380093b1c65431d8bf0e5964ee0a",
+    "rom_sha256": "1e3224b7f056fa600c9ea2ea6199a8500ed4f5987940efcaa6a868a0dee8debd"
   },
   "audio_pitch_mod": {
     "stream": "4ef344c1b745563313c683c71203a54d98d3f1ad111dd91d26bf59f395e025c8",
-    "rom_sha256": "303b5f4a02f6c8c98fe1e74c1d2bda0823bcbb0088daa3f078eb3310a4ce1144"
+    "rom_sha256": "a3b37a0a604257a8b66d4452c66ce3d69e2e9ac229d2c732441a7b5f1b72819d"
   },
   "audio_play_noise": {
     "stream": "c0a2753e24d3a0f262068dc10dd200c14577974fbc1b1e05525693bc4ccfead2",
-    "rom_sha256": "de35a48589416b0747a10334f1b834a189daf844b695ecffb44e69795d0cf934"
+    "rom_sha256": "fb4cffb026ef8047bf78cc6fcbb0b839cb075888cd91898abf6adc1353f5212e"
   },
   "audio_sfx_from_wav": {
-    "stream": "cdb97a08adda7a92a8bb8c3cad2cc8a947d1a519a4edf8c3ccc03f97151bcd66",
-    "rom_sha256": "877a345cfd94c1d84e3a54fbbba8fe8234319d179ca8f3fddd36e01a50bc903c"
+    "stream": "ddb0d86c633b9c04135467415dfffb40dfaed3842385ab6c7ec26b22845e5544",
+    "rom_sha256": "dac9683f7da7fc0b1b2d16a9748117bc36353dfda6dc873ef1e3afddab4a8a00"
   },
   "audio_snesmod_music": {
-    "stream": "e7130adb46fa582b03a8a2382d2f82173a162fb2be8f3832ff08042cd04d4e39",
-    "rom_sha256": "906f0b8f8131bbc4ef8784a218121443c22d5675e76449d9253ce5850df01417"
+    "stream": "19994e6abc9a1324ab77c66816b969530a58634216ca5ac3450c0bb5c70c6295",
+    "rom_sha256": "95e883e74d304fe14c30ffe8b8a18b2ba611b343585b857a335a136935e3cc51"
   },
   "audio_snesmod_music_large": {
-    "stream": "a5dbbd18a0933378160cf81b17859725b75c0043dfc4e11179f666ffd2a263e8",
-    "rom_sha256": "c78e82b979c7aff9b2594e300e95f05181b77508b022b27f7875ebb1ca1f2056"
+    "stream": "ceb328bcde05da4d1df4abd17ed298527c4b30eb41f91db6f8c7b434ec25c860",
+    "rom_sha256": "59fcb7c3f37dd1c6b5f6afaa84b4c4dfd0a4665976ed93097d91342d34d5159f"
   },
   "audio_snesmod_sfx": {
-    "stream": "4eeec068587c6287c33b70f9fbe4bccbdaa7d749106d9d60e04b211043077424",
-    "rom_sha256": "a2a89e75627744146de0ae726b638bdeb30521e20df9acb418503a3f35b6da0c"
+    "stream": "2e8b16e375b0f50f17ad4da81a0bf0379c593913f33967fac94816afb661f743",
+    "rom_sha256": "e1cb3f946d93f9c11ad97e13f6ae5d719ea4a27023133516289ae01f6e61d039"
   },
   "audio_soundboard": {
     "stream": "ea6244da9841da4b1adc39565e2dec87015d3971c517edfaf91a37ae33b936b3",
-    "rom_sha256": "13ca23abe61be23a1ad511e6f38429ca155731fbb7bf3ae9afb8de4e6eb1d6c9"
+    "rom_sha256": "e83e1ce9b1f598093c286572b599229b240b929f9e886ec4f0433ad09bf9895f"
   },
   "audio_speech_synth": {
     "stream": "2f4a80a1714f674dd6270a146b4a8e3aaac78f6ea4886ad60fdd2fdb899cbbd7",
-    "rom_sha256": "63da3d1f1caaebe7335a8f8416d6e24f503c526a145e59199b8ae42f0c4aeff1"
+    "rom_sha256": "e5426326663acf9e316e164f53fea21298cb3b52e18c9b9da3668a6a8d1097c8"
   },
   "backgrounds_mode0": {
     "stream": "59c807616140fcb4b91b9d8e02ae01aa316fb1a6a6aa47a693091db329d9f466",
-    "rom_sha256": "871fe14f3eb69798b3cfdd2e5fcb6e01bb893ab07746a87257039afe28b005b7"
+    "rom_sha256": "cde07b5a9653987377317a1585253611f7ca5cd3bd6dfa41ea0aac2633c760b8"
   },
   "backgrounds_mode1": {
-    "stream": "9e2863611c77e95bd2221f10ba8591ea711c13bd6a9b3dba97f7e0c3714ae711",
-    "rom_sha256": "98307aabfa285f767adf3d746326d1f79f413d9f7435ecc8528609bf09997258"
+    "stream": "e4a6b1b255ab899c28508a9d387cc4585247347b0a3c3a0014e5bb98b0d250cb",
+    "rom_sha256": "6e8c55dc5c8eb8ef8462e154e4d195e5f1d43b9fc95c5f3e68b0d05c1544d288"
   },
   "backgrounds_mode1_bg3_priority": {
-    "stream": "d9dc2da0049707e05958db42b1363aea7166acb719516642c4849b5771177558",
-    "rom_sha256": "173cc103a1f694258b16428bdce269b0bb30ff68f3fc37d7d264c62c8f6829aa"
+    "stream": "2154821c174eca413790ef521a86cc0712e2af3031950fe7e07d49d493e66dcc",
+    "rom_sha256": "561cda28a3370409c234cdf8d2ff8ca2a4c95ca8963f0f093dd2930309699dd5"
   },
   "backgrounds_mode1_lz77": {
     "stream": "f7c83ba43a38495e860df95885286e4fd7a6f1d9e6f21e9dfd2e26f9fbbc7b42",
-    "rom_sha256": "55aa21bd1add771e39ce9ab39cf603bc0676bf97e8e5ed6f0da71b86147704a6"
+    "rom_sha256": "17daf73df03a5bce2fb31874046239e9913af8f28ff2eb7dff4374e71cefe0c4"
   },
   "backgrounds_mode2": {
-    "stream": "e6aed34ccf63901ee1c5f3feb108e2f2de0ab406f82dc0f67901206ec018817b",
-    "rom_sha256": "71cec16d0cafc2a59060f8214b2db528f48baa3b5404ebb362b7871fac05c960"
+    "stream": "c4f49983f1472992bc71e1baf3b54b7297cf4f2f2cd68ece9a3d508c0bc64a34",
+    "rom_sha256": "93ab65d5ba4c0f9686428a999683dc69f500897df309ea438f3e83225c490622"
   },
   "backgrounds_mode3": {
     "stream": "d827f5f0c8653cfc29c00f1d3daa59ed8f789be3e9f0803dc680a51d290fb3fb",
-    "rom_sha256": "7d72b97c0b16bb71e29abcf3cb86f218feb2c83aae973bfb2fc9d310b7e07ab8"
+    "rom_sha256": "fd3ddf88db28376e6be85d2016da24bbb25f60b3ae1efb582570cb4a2f5ac800"
   },
   "backgrounds_mode5": {
     "stream": "d8465f7accba316aedfa108691a9a65e7a83b5aec6c9de20c0dd3e1f4e8e1422",
-    "rom_sha256": "3f4f8227d1a6eace5a6ff8f3adf2333b40f24a166f32c81bb3f0039b8dbbc2d8"
+    "rom_sha256": "3df37063f96dd1ceade026777eb3ffc4065d812ed62a1c2a2960fc80e2c976e3"
   },
   "backgrounds_mode5_hires": {
     "stream": "fd4df98be58c25884118d860e374516a5451d1c7318d04c9777b4db01aebb767",
-    "rom_sha256": "6d103fa832255df3ed76453e87690ecf11d76dce37aa7b0959e839071138aad5"
+    "rom_sha256": "db2d73ff78ace7d9dc565db7adf824e2e09bc0ab2ffb000f9028e5b631b03aaf"
   },
   "basics_aim_target": {
-    "stream": "39bd85224da948bb5aeab9ee2b8cc8fe79a6d7d83abde282ec0f7cd868158831",
-    "rom_sha256": "8374a0c81fef685bba67bda5701229d4423ca5fa085c92ed2b1b46ec8e93d598"
+    "stream": "b31e26201c5e1934c299497df8afba81fc78f4258f90c16d082028fc2c052fc2",
+    "rom_sha256": "639bf5ab85c51646152fc62e23d7884942200255eb29b6e0320dcb76f9f8e989"
   },
   "basics_collision_demo": {
-    "stream": "7ced0a8fbb275a7faefb4ae0d7aba2bf101fd2fe923844121259801f31e28d0c",
-    "rom_sha256": "7ee9cd946abcf9ea3a1275627be8515b239cd1d9503f9a931f1c89d674cf127f"
+    "stream": "4cf0b27fd36678a8429fc8980210ac78d77c564088626aa546be80383a354fe6",
+    "rom_sha256": "3e07eb58eeaf112d9cada62df1a729baab94cb959b6b10bdf0123f6a1b745fa5"
   },
   "basics_fix32_orbit": {
-    "stream": "ec3cc3d00fd2e4f8f02aaa6ec1d7aa8eb23c8ef532357dd10fc9c67ca91298a5",
-    "rom_sha256": "4f87951d30c82075cfaababd4274a92c78da77037ac56278205fdc4ab8a468ea"
+    "stream": "8d8cdf891e2c077bf47c499037a258c16684750d43312617be8bf80698e4cb9f",
+    "rom_sha256": "02c88b85a01010aacdf7e36286d38409c67491e15890d0f279c8434c62bee2af"
   },
   "basics_game_skeleton": {
-    "stream": "0b8cc37a1428df1343d86a1e2f379b55276c6b4b326c01ec845ad67e13badc48",
-    "rom_sha256": "c8d66d360527ad78b183eae5769b0c6494eda1adb3195b2755ce5a0a8b4f5d66"
+    "stream": "c821bd05f6825ea45d9f84a472bccea7ed68c5ba87808a38109ae8618a94807a",
+    "rom_sha256": "686c00e5766ecd0ced74e8976405c116239f6e4e7eb968ba82ae763ef078cd37"
   },
   "basics_panel_hud": {
-    "stream": "b9c0bca744f6caf1a06561687c417665d246e62f24be8585e5908ec95d5a3a44",
-    "rom_sha256": "1b144db99c892353ad72c025c616628ba05319bade3643f6e1b48cd3beb038ee"
+    "stream": "774efe972d7ab15c46645bb7fb9fb3b49d008195ab0294cd4f39413c0e064687",
+    "rom_sha256": "43e73dd8920287562cfb6674a9ccfcc96fd80ef506b7d8940b51be04cd495fb2"
   },
   "basics_random": {
-    "stream": "8f283475a3d9d2ef13ff1f3286a52db0b01e6ad119233391e5c39c628ebbe04f",
-    "rom_sha256": "f75253a2e8e4d2bdb8414a3b71f4891e30cf1ee24e62057f72c6683cdc4bd82f"
+    "stream": "a475cf8558b84126b51c98f607db606c5e59ab37d9fd51e72543a90c5751b304",
+    "rom_sha256": "252a8e34f7edf40dce91601039696ea161f8885468c213c1b1715e72ffc1e6f1"
   },
   "basics_scene_stack": {
-    "stream": "698741ac8556a6170ed9a3ab9c445c61542fa3ebd39e3e2cd90ddc0e0be27cfe",
-    "rom_sha256": "9515160519e99e2ad7984423540efe901ff981738946278618aff4b80ddb9331"
+    "stream": "245e6b3e4d7de4e863f00a79cb3bc144203dac3011a90a69b7e8fb57a7871f8d",
+    "rom_sha256": "a326dd09436436080ae245eaf196a4a9319c07d323ba85a4e1f115ff0428c60f"
   },
   "basics_timer": {
-    "stream": "5daa57fab82c2061b579926245cdb0841e0086bb18e272f6d4a108b8ab5ed839",
-    "rom_sha256": "cbcb1713395456dae0413c92e3ffc30a0f08b0a67cb2a527dc4c3b45182f1752"
+    "stream": "ee55c6ad251b724424181d03e62c0f47da793eab1dee8c2dcb9b39d4f41dfd8f",
+    "rom_sha256": "9ea9a04dda808573ce7637cb07d2e44a6a824b84b0121241c1d350e8d287696f"
   },
   "chips_dsp1_cube": {
-    "stream": "551f4da9fe1933654053a20259b65391329a0df64b0c5a2880e50c6000465cbe",
-    "rom_sha256": "a17698161e81721cc98d4cfb6e0e60f964865d6683b776381edc546c929da37d"
+    "stream": "b5dd847146d08e566a92d65cdf47b8a26e79d0c4bf4306bfa40841a59a295ba9",
+    "rom_sha256": "c246347dc8a49802c1b7d35db7d6d38ad1cc1a76a43b5b67cb505870e284389a"
   },
   "chips_sa1_hello": {
-    "stream": "4d7861df6d045c5492c0145526254846b889e01b4e64b2d49b05f9bf9170b719",
-    "rom_sha256": "02c08aed2f0b346e77e18b51972fe8eb071036a9829a78b364cc9f926ccb77a9"
+    "stream": "a9a0b791d408cca9156853bc6e81260f920b459be65d0e0f5ef2082493f82b9d",
+    "rom_sha256": "33b3fbc1a3f44abab9e03b6c60c36cf82145657eec979f9d3f14428b36fa7730"
   },
   "chips_sa1_starfield": {
-    "stream": "6321278c2961a93676b026829b3782f546c5d023221ac1894e0b392d6382b237",
-    "rom_sha256": "e8139adc061ecc9ab7ff4baaa0b7db8af52c56ae3bfa86919c4cd2bb963dc8f4"
+    "stream": "fa74e1f9516771d679d6ef412f87061f339a58667c0788f3dfb1398fec84010b",
+    "rom_sha256": "799f919e6c0e9f2bdce124edcaa796d06d55a2d72f75f8056e7ad35875cce945"
   },
   "chips_superfx_3d": {
-    "stream": "3c0984d0e7eb69a2e94abc828254cd282e6cfe1a1fc26d5fd25ba1cedb13b5ee",
-    "rom_sha256": "3dfdd21e827e387faff38e56d51b74494ab08a5587929efb976fbaa2965eb9c1"
+    "stream": "58d078b52de00b582bb7c35e590e6a946f13e7d3f3d05b8918ef3ecebd10ed21",
+    "rom_sha256": "e7de2797ccf7596cf861b94794d468e37ffa322533ae9a8f760cfcc24aa92b9d"
   },
   "chips_superfx_hello": {
-    "stream": "d62d0e1b0729434a12aacf2ed93f68919afa7d164878aab23932eb7124314c2e",
-    "rom_sha256": "ce1b187823e8eb9c7ee73dac39197049f158a6dfb9af2eae71666b4c3c0823ae"
+    "stream": "29ad032d0fc33d2b8332dfb56594cf5c2055dfb960f70fb59563226cfa17473c",
+    "rom_sha256": "eba245cff778d9ef958b63f4a66bd3b8a406725c9cb0cf5ca5c67c6b04de0a54"
   },
   "color_direct_color": {
     "stream": "e316228a0762d29e00557f0bd8c1de6ec04b82da68f1e7cbdd95e03b05037db3",
-    "rom_sha256": "637179d9e689966f8878cbbb0be95886bb68ffdbf4c2aafc3b691866af7bc6e4"
+    "rom_sha256": "b60fabd45883e1d822552119b62f39bfa73029abb9caacf2b202749c1e53a186"
   },
   "color_gradient_9bit": {
     "stream": "b0018f7bb5901526b7a373da10d05f8155a0937c87a8e5696a57690a1380307f",
-    "rom_sha256": "f3a7fb708d081b7202e8ffc954e79acc034baa5c608f6ed6c41cc3f7922275fb"
+    "rom_sha256": "21d98cfb37afcd8fc411d1f3daa272f685202630f8c11f78ff2caae28035bef9"
   },
   "color_hicolor_1792": {
     "stream": "abfb86b282eeeca4b6bab391fa795619d39ae246aefd36d3b0f38c953ead693f",
-    "rom_sha256": "9faca5e975cb2d804c3a4a4bec2dede29bcbc2364c326fa2a5a089cf1cd4d5e6"
+    "rom_sha256": "a66f4fa1a1689d2f6d20a4e19628f45772a8e155659c4ba8634f6d90be210de1"
   },
   "color_hicolor_blend": {
     "stream": "4d7ba88f40a11e4f82748eb92c1f157010d35e0d7319430b69de2015781b9079",
-    "rom_sha256": "5ce530df69cdc6c322bb717a5b0349887a6583770f2e0cccde8e09fe2e8cf5c4"
+    "rom_sha256": "1f9241ae52aad23b467dc9ddfbba6a8fa6e7bdfed3c9913bed310f7e3f7aa001"
   },
   "color_palette_cycle": {
     "stream": "78856cfcc28b68e4e744a16b7e577908dfd1165b4d2989a3d36b9c80e5fe617d",
-    "rom_sha256": "2ed15dc826ab769b3ceacc75e2e2a180f4bd7204bef7dc04e7644cfc2151b396"
+    "rom_sha256": "968fe8a340787cf78a33098ef9de71aa5cbcda8c8a72fb7d9d7ee84c755fc33e"
   },
   "color_shadow_tint": {
     "stream": "33ed4b676c89285ecb29f6ee3fcabddadef1ac35e7f61817fa67116323d3b7ee",
-    "rom_sha256": "8df36c907b8a4b7a19e4eda6c2a22fdba053237dad7a6e5bab63ec4a571f6943"
+    "rom_sha256": "86573175130f21dbcf0ae9c3199a374fd68ae5a4dc4df7b34070376cfd3cb8b4"
   },
   "color_transparency": {
     "stream": "c68e297576a76119073b2edbd6beb33a55cd2b52ff0614e2370167841b333678",
-    "rom_sha256": "f71c8ebc61e675dd39ba32ca34e2d3d0453a3bafa446375f6eb0bddd4a72759c"
+    "rom_sha256": "73f64be729b90b607bf4e9109b383b9c80abcb918df4cf4c268e6f78ca6077b8"
   },
   "fundamentals_text_glyphs": {
     "stream": "795923aa4cb6f948b44cd74cb0baa2aba97400c0d3794d272ebec2803d33913e",
-    "rom_sha256": "8c91134f6ce002be1b1d9464a7d1238f49ee3c96c5a40f33171a153523f8c64b"
+    "rom_sha256": "34f34a4dcbb6a8c734f82869508aa483ef9c38d57f2b4c5c02ececb7c6ad7a1e"
   },
   "games_breakout": {
     "stream": "b8d5400377d9210e74ef024520a899d609d6e5eb1ad3ad6e51cc8db34d313c4f",
-    "rom_sha256": "f766a46de6cb84f9f0a5fbaeaa06ae3e74c16a32fd53b46229d59c88e4b2e0ae"
+    "rom_sha256": "d4fd47dac1fcfa1d33f994224fc96753e43725a1bfd17245daca4a019dabd024"
   },
   "games_likemario": {
-    "stream": "5d4e386bf1db283d79c6329417b00295afa0c4ab567f1ebaa3d6c136b1730ef5",
-    "rom_sha256": "fc83673d7da5505cca0b35eaf5ecb837484f478ac1a2fedb3930dd6d33e9ff03"
+    "stream": "b966741c2269d9ee9f90b916a16a85ba06051312b30b42e1cbbf5f96937bca07",
+    "rom_sha256": "e261421d49e64c7a9658be5cb572334d2016ab42599eafcb5f844e31fd8823e2"
   },
   "games_mapandobjects": {
-    "stream": "5d51a6a9513281566ffd217d4a9333b5a85be4d60c312b205167facf4e66192b",
-    "rom_sha256": "2cffb1ad2405200eb82cd93c66da95a6cda614cf7b23b5ec63caaa626a735a08"
+    "stream": "fbd23cd1392455ec5b9ebbfcec187a6817fde95e2b9d9e25f3682944e2f47b68",
+    "rom_sha256": "e506a5472661568d7c891f3483b9b479c33b1a487d6fb96cb72109dbdbc2de7b"
   },
   "games_mode7_flying": {
-    "stream": "5a5d14fa5689ddb589033ed8b827aadf17b563ab9c63d217d29c5305289f2e90",
-    "rom_sha256": "04f80cce4ec481d14846e286b686af021f887f9fdcd996028febb1b6d2318e87"
+    "stream": "98cb4429a79f063fd58aba9dde0516a0e9e1afba88210f4d1261b193c742b929",
+    "rom_sha256": "4242e890500580d9c123c8bf58fb48469a0e8d8bc2341c43882722e38c855b49"
   },
   "games_mode7_racing": {
-    "stream": "0dd4b4178af1359917a37d6642ce95b401670db8852a16675bba3506cefec09f",
-    "rom_sha256": "579a1b4ed88a06f9090b2b9c566406997dd8b4bb6c0b05e90ac13bb0e19eb1e6"
+    "stream": "c9b9839ef77f5694d31a6ae6c2faf0a9d170a828aa5dbff5ac30c1856fde636f",
+    "rom_sha256": "b8510ffe9b6b8082fc2e26a68266094cd9482871bd5f559dcd8c8f9d675e5c05"
   },
   "games_rpg": {
-    "stream": "0354e1a5589197c7d792aca72c6b17b29b31630dc26708790c642506a538aa9c",
-    "rom_sha256": "856891b2e88a3ee8f72e1119dfc2fb7438af960033bcc0c16a29151d14acdd33"
+    "stream": "9a1eb9399e3cdf57539a219afdb997268bad91356ebacf94be02b86cd71e218d",
+    "rom_sha256": "32e0803f1d0e181e2d8cbc1ab828adf66fe7de5686f2be270fe47ffc93f19fec"
   },
   "games_shmup_1942": {
-    "stream": "cad62fa67df007b7469a3c03a83dcd4cb4eb0b481d4b5f7405b75f90bb0681e5",
-    "rom_sha256": "ad9ea07eeca03e3596bf1e7a973266683f482d38353c0249be5f016ecc2d0f79"
+    "stream": "fa809e4a5d1bb4da7d3eee49f327feb20a705c6caa69b44c5c9e3a940db51acf",
+    "rom_sha256": "eca22fcd8d33a65a1b128dfe959c1f41b250e4bde9df1a9bb6a47369c81220b3"
   },
   "games_tetris": {
     "stream": "98f5299924cb60fc5e4b49aa159966f141197162853e4735838eecd580f919ee",
-    "rom_sha256": "db6e3dc84e7e221fd54903b6c31a8de1263ab143d3f622a80657bb73c3635220"
+    "rom_sha256": "4b038c48ec25cf9dd973e3ea8765ba8651743180e04e0fec89cf37987a1cdc21"
   },
   "hdma_gradient_colors": {
     "stream": "d40e8e2172db0f3bfd273dec183c0aa62a0f208b0d347af7070d7950bd1ad42d",
-    "rom_sha256": "34e61e141d144761c2e3abec93e4f9ce335e53520c16574cad649535cfbb4cbc"
+    "rom_sha256": "51514ac28ba005c2ffd6809c02a22f44d30f463db7a88f91407ca81b958de779"
   },
   "hdma_hdma_helpers": {
     "stream": "d81172ca4ab3365745d9a9a92b0d8217fe98e6e3198f3a0ddb36cf8b6014070b",
-    "rom_sha256": "a2159b880c724e006892ce9b187df7c0951cadc865bd17d4ec35d7ba99b4745f"
+    "rom_sha256": "0bc9510a2dfe52a7fcd455a21e83f74a7efcfa9293c05127ff6eb94006da42ea"
   },
   "hdma_hdma_indirect_gradient": {
     "stream": "a2da247476d83f9533abb54c22f8ace807df756b6cf2feca04ebb1afc0adaf5a",
-    "rom_sha256": "445b2138d6ad595c5e51e525fed9ce2a2b056d1afbb017fa20ca0c23bcfdd8f8"
+    "rom_sha256": "44efc65ad6f4e653c9e91588870c439fff40e4648401d1edc4e9974979921b3c"
   },
   "hdma_hdma_wave": {
     "stream": "b1d05afe8335792bcd0b25e1a90dc2de2fe787e0f68fb21932f3ac6c29ee46fa",
-    "rom_sha256": "4d55b116af8f9372d43284be6604534f0853f0fed09a8ac1aa6916f38d2ef56b"
+    "rom_sha256": "2906b04a2703d14928788c8d2e665024df645473d5ab4002b1c2f16678e3036e"
   },
   "hdma_hdma_wave_table": {
     "stream": "88825ea81c6937c51794196c3fc26e654f4ee040c3d298adf864b01f5fece3ef",
-    "rom_sha256": "e7da040d0c4a54c6ebe4176ee99acaa53851a7d1e2e641ae49bf3cbe41168b2a"
+    "rom_sha256": "0a702fb94cf97a6bf0dc5a19149d1d1998877c9acd6130e73056fe3975d680fe"
   },
   "input_controller": {
-    "stream": "04c844b844135c435bd25a40cc1a362a3440f8008f7190cf511d370bf6ec5d87",
-    "rom_sha256": "41d4a5ec20b47ee94a7f3e24a0d61b958396bb41f518eefce12677adce77133e"
+    "stream": "84a32d48617b7a243a10fd8f1e4b1ab084d70ab1d63c63dfcb6a59972effc932",
+    "rom_sha256": "bc9a1b66eb7da080e7f161263f949f679149661069dda446d2be372a94caaaff"
   },
   "input_mouse": {
-    "stream": "a4186cbbc64e47a4a847927de18430138ee867fe0aadb4af4f9d7f0fe5290aa0",
-    "rom_sha256": "27586ce23cc457ecdcb881177b23fe29ba8820f9855f880ac238b7b6c764e850"
+    "stream": "db02e998a7d295569410235016a08de2a959130a570677ac24bfb947e6942fd0",
+    "rom_sha256": "0d900ea06679f2e3d364ddd6114c75b914964077744b9616a077bb32138d6ee1"
   },
   "input_move_sprite": {
     "stream": "3c19f66fa03799ed760fae23014e9543b5f08f10cc11873e0983415bdafedbb0",
-    "rom_sha256": "fc167bc5f6ddc842dd8e54a859930fc6dce80e47250d535690cde38572b93693"
+    "rom_sha256": "c98a71a6ca791a72678bc09a2e4109d164b4f7295696b38c11c9404a06d4bd34"
   },
   "input_superscope": {
-    "stream": "0e98ed58c72608c9cb0a5c90800dbdbb44cfb13e0ed77985114032f80d8b36f7",
-    "rom_sha256": "54407ec39d2d4152296e115d82cd183eecfc9a2153c3fb2def36686ab41adcc9"
+    "stream": "92e99a07b479a0ae8130e8cf81b8b1644b6a183839f15f137bb1810386147c6c",
+    "rom_sha256": "ffd3d30c683bfce5185c8d64a29d210b056915ebb9f23dacf9d7d346cc709978"
   },
   "input_two_players": {
-    "stream": "ac8c587b8b7723beedebf8323b1fccd973ff4baa18a81475bda700317597f402",
-    "rom_sha256": "fb1f45d8e85533851c60b20ddcd7baa015fe4b5982ffa6f2e2f7efe729afbfc9"
+    "stream": "0cbc0d2adf2cb1fcd9cd7477b160f78c57cb01e8df89644468add09fc0d36cd2",
+    "rom_sha256": "e296fa6e0a6b7235a76c7bdbd7911528b9933f70cae0088937280e58b9cdfd22"
   },
   "maps_dynamic_map": {
-    "stream": "7708e287b40720ccc05e114073ebe009d1eba77f92c6a756a8b76ca8be874187",
-    "rom_sha256": "b4c420e96b33999fdd001c64291fa304152b889cc58cd5c33e963a0546fd6e51"
+    "stream": "b5f70f13e5a7717e0e34debcbd5271e887a755f10b357dcdd7716c66e6aea75c",
+    "rom_sha256": "d6909fc6edf4c0b61be828d196884cedf2f875c26ec033cc8cba22b4072f550f"
   },
   "maps_map_scroll": {
     "stream": "f61cdf91e2039f2b70ecda345c566cf654ec583e1ef4e54f773ab066aacfa5df",
-    "rom_sha256": "33e38d004c3990f2d298a472f2a0f34b6ecec52060f5df4636287bc54fef4b9b"
+    "rom_sha256": "2c5d3c084120361370b7b4229873aad183aaa52f544e0ebff7100554e7868f92"
   },
   "maps_slope_collision": {
-    "stream": "9cbc2d7c6641c2c67e55c9c13f581ba39f13e4b71af061d1345f0bd8f02bbe46",
-    "rom_sha256": "3d73947d40f0897291e808e48dcb89add223f4fd3b0851b57f954194b6777a2c"
+    "stream": "2c69fb0d9b066872980394beafe5915ac59190d1bb92aa895a38739fb37d2d45",
+    "rom_sha256": "7bb75c465b358220f8132398129fbed726ec31d12e14816cede11dafc3200408"
   },
   "maps_tiled": {
     "stream": "e8639cb72466cbd4e725269900347a09a53f5d64b9d5d3200520a8630490cc65",
-    "rom_sha256": "2dbad8a5388548ededae26f8a77075338ade48bb03dbee3c4a40468b0ce7bd78"
+    "rom_sha256": "0953aa13b51dec9327bb4200c0baef006ef2e02223d31f20d20080a0ac74614f"
   },
   "memory_hirom_demo": {
-    "stream": "c2138ad501a314a0622e51e6d79f8ba7dde242fc510eb78b54612072bf2ee914",
-    "rom_sha256": "134ab2f1739e27ed1d98481735f0d852d75a2170b22e0753b4dc7d6604d3691d"
+    "stream": "62bbc8caf7ae6130db8371512bb3546aa1ae47b5b6e91c42cededb3d314d079a",
+    "rom_sha256": "8789049d4e61dbf7c055b7fe27eb2fcbbd9febd014aabbf41687aa15fc420ff5"
   },
   "memory_save_game": {
-    "stream": "9d52e8ece8209f8ff48b37858c56ad6bbeb5156ed8c50e9aa97d271dc55e9b70",
-    "rom_sha256": "606a80054bb8460d6b5a16b99322026df894795b2e46da04cc77d7a537a9f72c"
+    "stream": "317ada0969df5e3cc63fc442eb6dce422d1993f6bcbe1ac52983bcbbdc795b1a",
+    "rom_sha256": "fca57297531399d54e33cea74f93407e26e821cf2c0081ec0103ad158a52b078"
   },
   "mode7_dsp1_ground": {
     "stream": "c88efc9985104ab3dcbe9a5cb31d1bb9bed68bf7a4f1d8dd9ad2650b324fca19",
-    "rom_sha256": "d5d5b53fbd8c812acb2b1beedcc879fd9fccb6eb194e90906762ed36cf4ed156"
+    "rom_sha256": "f1cad427bb68e204789938c5d126841c7ffb22141b3086524ade8b46e7d9b8b6"
   },
   "mode7_perspective": {
     "stream": "d9622d33808a33a9d69b535341e98850b62a0d4be8135e53792f1e6927f1a6a2",
-    "rom_sha256": "2d7ef2ee54eb83c67a0d451a30934194badc3e9588d3de557f70e987a9c8ead0"
+    "rom_sha256": "81a3a1d4236b9ef24f69417150fca3011a404ee8c1a1d9e5e44df7afee25e05e"
   },
   "mode7_perspective_rotate": {
     "stream": "d7f8564f4deb6991e05a86ad78f9243c0c52e5c37715caab6838451c024ce31a",
-    "rom_sha256": "95b769a7bece3058aea05e6a0598b8a3c4440b33c4177de8c51a192283a288ba"
+    "rom_sha256": "0f44a452469b042ae740d48affb6a678d1dc42da7f99e5fc38a9dca92ad3a3d5"
   },
   "mode7_rotate_scale": {
     "stream": "52576f629f5d7011af0cfdab35bf698ac8dd1e01d295571ef270b7a6585301fa",
-    "rom_sha256": "9b50fdfe306e39391522c788673efef8216f946e368e2b82b28ce7090546e44d"
+    "rom_sha256": "f01d5ef5e642573f5def81580182c6ffdbf9d53740a2f9a704dab95d15182019"
   },
   "scrolling_continuous_scroll": {
     "stream": "d11d968455e6dcc1ef93194a35698ffd6a9b8a7c4ae8c1971b20489492565380",
-    "rom_sha256": "70f3bb6134811df7b22812b018ac8efc9fcfb29415aa3f992b0febc19a28e9f7"
+    "rom_sha256": "ab5dc520ded85aef3b228f657ca4d731ecfb2e0e880ba1531f72679de78ddede"
   },
   "scrolling_mixed_scroll": {
     "stream": "bd9850146135362c666630813cdaf6f86cdd903b8beab86bfb003f62b41bcb46",
-    "rom_sha256": "4efb9f286c33761eabf3c86f964621ce1c7fa952fc5e39f24e5c83f16c78260a"
+    "rom_sha256": "9a4ee99c209dcb70742819c5b33f59181fd6a040a394e5387a7459bb543d4f72"
   },
   "scrolling_parallax_scroll": {
     "stream": "cbdc47cdb2bf27f1226f7196e265d0e2e349afbf3444f80183975faf2a63727d",
-    "rom_sha256": "82ede33d17713c6ac07ec24239239585297747e1e82723d7759d5ad728a33afb"
+    "rom_sha256": "fcf0d8fdd9067930748d2d1a98ea3708f0194ffee74eccb0a3e9219854477443"
   },
   "sprites_animated_sprite": {
     "stream": "cd318e4076632c312749750612b320e7f3abe860470822b085902e9fed306eb9",
-    "rom_sha256": "c1a449aefeaab294013a302b5b6fdb89d2ee97ebbb2a7b46b4be4c8ebd69ba19"
+    "rom_sha256": "715ba9158123d276be00d93dd6c6601fe33c17202598e2774f06bcaa0e988f09"
   },
   "sprites_aseprite_pipeline": {
-    "stream": "adc48cfa4eb952fcbb91c66e86f4fcb2b432dd841cdee5e1b32d849aaf01c551",
-    "rom_sha256": "238aaaff6f73adf22e749b7a3eb9f676150422a880896e33c336d25bd3e9297a"
+    "stream": "40bbf0b9d93abb4654bca0cedb375f427363fa1bfdd546b8ce4a92d1cb90cca6",
+    "rom_sha256": "6b80ff50095617fca835bb922fc948c61ecbffad0f3140c1cc6cc591767a6ff5"
   },
   "sprites_dynamic_metasprite": {
-    "stream": "d0a736a35af7118fd35406876219ad86ab23520c806c45e3ef048818f18f16df",
-    "rom_sha256": "b1a790e8cd6de196f3ca392926c22c4f0e9480bcfa4907c83aad3bc531eef1ca"
+    "stream": "f5326caae3fe30d71c775c4526fd8449846e8a60cdd6bdfd45a205c870776cbd",
+    "rom_sha256": "9a169084577bb3897ef5fd32a7a89a2813b92ee50be5b1c34c4bb7e143e07809"
   },
   "sprites_dynamic_sprite": {
-    "stream": "63cb51bea0a7b4df42c5a235ad84e2555301b2ac6dd801473e8ec593d91233d6",
-    "rom_sha256": "fb093859ba46bf451a2440d6dcf8df8a46dce842ab1406f5732eb6d4a79b0d80"
+    "stream": "79a98bf0477cb29595e0996ea5e5564f0eadb57b4449f8c8509d74c77b663d49",
+    "rom_sha256": "89714a63f3f7e1467457477a8931f909c388ccdec9a0f870f1653a8cea34123e"
   },
   "sprites_metasprite": {
-    "stream": "7b9e5f50b222c1c7373eb957a53a284bfb36427d92d4cc63cd01926288d47898",
-    "rom_sha256": "c3196ef6372bcb847b19084e8b0ce079439bfd92afc5601cba993fe0ea0b2d12"
+    "stream": "62f3ece9f36874f62384de56edaa6d74e4a254d5637757a45dab16591194cfbe",
+    "rom_sha256": "6ab0e2efe21d9fb187ae7b9406f9739420104175c354f3385bd7fc22d94b51b4"
   },
   "sprites_simple_sprite": {
     "stream": "cb89da5c5d65701aeb7cffcf960f15919051ac7ae7d987b4451f5aecde778ba6",
-    "rom_sha256": "2f6734529c7a0d6af5f47344e955373e918c8baf88b8b27e039e1348f796f2f0"
+    "rom_sha256": "810daa49cf0634261972f412de6958553be23a93e02d4a627605b12dd575e38b"
   },
   "sprites_sprite_sizes": {
-    "stream": "f83e73383b009be54524e5bee2544aa0d7f3bf852fc902e6aac3e4aca2ee9788",
-    "rom_sha256": "bc79d7ee9ae1b28a8a1745f5e765532df9eae8ceb8693a145cb4093b5fe5ebfd"
+    "stream": "589cc0059ceadb1bcb2d769d5ae4236bd924cf19b3cf64eb6097b50b8b652ea2",
+    "rom_sha256": "e35940d2a227672e12cdd1b265817078a8ede5388dad8e80231c98cdc50c7819"
   },
   "sprites_sprite_swarm": {
-    "stream": "b26756112fdd7b32cd0ef7f2a3e9de3479b653203c3b5112614b1e897ac5c7d0",
-    "rom_sha256": "f89f63cccea73fe7fc3807ade114a71d866261ebf47b5f39a35d57f6387b8bd2"
+    "stream": "5087dcd5a9cc6a971ee08b928d660e8630b68553741c108e6b1058aec7ecbff4",
+    "rom_sha256": "cd95cd0f471ad6abe2bbc709fa94e595d6aed87552524ffc33e2c15503374393"
   },
   "text_print_string": {
-    "stream": "ef384c36566c43ce4d62729576dbf57e667b3e0d45571b40cc5c97d05922ca24",
-    "rom_sha256": "e95d95f577461274dc731c2170f55ba6901e1f43592091b08a2df97f7a63f3d0"
+    "stream": "e46b3d5de101531f1a2ce3a1f759493aabef1f5f280d03955f3fe80557febcbf",
+    "rom_sha256": "03a88580a1397d1c324ded19a830e9a14b012c965a239a66142d217a078b5659"
   },
   "text_scroll_message": {
-    "stream": "5cfda5491838715ba674fcb73950b7d345f66309a716656c09e273efa577538d",
-    "rom_sha256": "4c7c850438caeea8d1e3bfcd937d2fd00fb04c2b0c722e2b47ccd30a10c2385a"
+    "stream": "631607d3c1276879881844f6235dbf7fb66d4e5553f41969973e6a6a135cda91",
+    "rom_sha256": "b9590ac63a552463bcb15ea3628eeab4e21f18836ddc4e4808468fe8d0d0fc67"
   },
   "transitions_fading": {
     "stream": "fcee843da30a0aa8c4a20619b543343287475b7707469596e25e766db10c4476",
-    "rom_sha256": "180d925d356204efaea4658ce2579029155a332c6e59ba37db5610d7ddcb3d4b"
+    "rom_sha256": "3dd716f315af1dfa7a9389d6625ce8e37e5dfdf1df06db05c4c9b6cb1c027398"
   },
   "transitions_mosaic": {
     "stream": "7ba6a679aa25af04c8419bf0fae269596fe389c5a8d170be6163743910321aa4",
-    "rom_sha256": "6f1623101d54da5694cd5085787370269325ac74c527a696f98f871d1d3ab02f"
+    "rom_sha256": "e0d5c0ed585f253f2d38ca0ffe41e43cf35d2ac7ea2ea51d8e80427b015171d5"
   },
   "windows_transparent_window": {
     "stream": "11a4fb75c5b118c83ccb4e03d75c4f52bb29f1c59f72a89a73654b51927ff483",
-    "rom_sha256": "e428ebbe4c37176db21e20716be7b0c278bc75c3e02464cffaab35e09d4c2fc4"
+    "rom_sha256": "d0c7f2aee2013db998f85c44535f9fa9572802ddbad121e5c4901b2f146b1961"
   },
   "windows_window": {
     "stream": "010481a417ec2f8dc3de091b5750efba0ad1eb4c4c88b21f14a76af3f07f539a",
-    "rom_sha256": "c69c9f455bd1c59e3a69e715369299f0325962706ce59fde7ab956ee59f436b6"
+    "rom_sha256": "1b8fa0a7ab8737cbab837b8d4f89fc66093c07d0711c8715f4185eba0478abeb"
   },
   "windows_window_multi_hdma": {
     "stream": "82c22ee088750d3df44fce364142c1dffdef6805472c03669f851e5f79ece820",
-    "rom_sha256": "376b4d9efb5b6baaadbd86140db62d3c54fe71b5243e7ab36f1dbc49cb6117ad"
+    "rom_sha256": "644db64864fade688a36d6c06382183d42216fa8b8240e1d894c1ae8aa0e2c78"
   }
 }


### PR DESCRIPTION
release: v0.41.0 — the placement release (#127.3, HiROM full view, wla-dx fork patch)

## [0.41.0] — 2026-09-07

The placement release: C const data leaves bank $00 by default, HiROM is
addressed in its full 64 KB view, and the linker fork gets its first
patch to make that correct. Plus a bench that finally measures the
const-path gains, and a CI moved to Node 24.

### Added
- feat(compiler): **C const data is placed in the memory map's asset
  banks by default** (#127.3, closes #127). QBE emits every `.rodata.N`
  as `SEMISUPERFREE BANKS ASSET_BANKS` — the directive `ASSET_SECTION`
  already used — so `static const` tables, string literals and const
  structs land in the asset banks (highest first) and bank $00 keeps the
  code. Safe because every C read of const data is a far read (#121),
  every lib call carries a far pointer (A6), and `check_bank_reads.py`
  fails the link on a bank-$01+ symbol read with bank-$00 addressing (0
  hits across the corpus). Bank $00 minimum went from 12 bytes to 71 on
  the code-heavy games, which now spill code (not data) into bank $01+
  the way `jsl` allows. Visual regression 85/85 identical.
- test(devtools): `benchrom` gains seven const-path workloads (animTick,
  animTickMeta, const pointer walks, const→RAM copy, const struct
  fields, `tab[i]`), the instrument the A9 optimiser change lacked:
  v0.39.0 → v0.40.0 measured −9 % to −54 % per call. The runner reads
  every result from one luna run instead of one per symbol.

### Fixed
- fix(build): **HiROM addressed in its full view.** Every HiROM unit now
  carries `.BASE $C0`, so a label at offset $0000 of linker bank *n* is
  addressed at `$Cn:0000` — the only mapping of that half. Until now the
  runtime's `.mul32`/`.div32` sat at `07:0000`, a WRAM mirror: any HiROM
  C program doing 32-bit arithmetic would have crashed, and the 2026-07
  attempt at #127.3 corrupted HiROM for the same reason.
- fix(compiler): **wla-dx fork, first local patch** — `.BASE` no longer
  applies to RAMSECTION labels (`$7E + $C0` was out of 24-bit range;
  `$7E + $80` under FastROM silently gave `$FE`). `symmap.py` and
  `check_bank_reads.py` fold the `$C0`/`$80` window back to the linker
  bank; the `.sym` prints one valid CPU address per line, which luna
  needs.
- fix(lib): `consoleNocashMessage` read its string through a 16-bit
  bank-$00 pointer (pre-A6); it goes through the 24-bit pointer now.
  Caught by the `debug_channel` runtime fixture the moment string
  literals moved.
- ci: the workflows' actions run on Node 24 (checkout v5, cache v5,
  upload-artifact v6, download-artifact v7, action-gh-release v3); the
  deprecation notices are gone.

### Changed
- docs(docs): `KNOWN_LIMITATIONS.md` bank-$00 ROM entry rewritten (code
  only; the one bank-blind path left is an explicit cast that drops
  `const`, guarded at link time); `.claude/rules/bank0_budget.md` records
  the shipped default and retires the "what still blocks it" section;
  `templates/assets.inc` HiROM caveat resolved; the two open hardware
  claims (HDMA mid-frame enable, INIDISP at power-on) are arbitrated
  against the SNES corpus and cited in `hdma.asm` / `crt0.asm`.

---

Pre-release checklist: `make clean && make`, `make tests` green (compiler 18/18, coverage 83 OK + 2 input-dep, visual 85/85, manifests 50/50, WRAM oracle 85/85, lib assertions 31/31, runtime fixtures), `make lint-docs` / `make lint` / `make verify-toolchain` exit 0. Submodule branches pushed: cproc `6d3953d`, qbe `ca50db8`, wla-dx `86df331` (`opensnes/ram-labels-ignore-base`).

https://claude.ai/code/session_01SaBKev4cAfdNKbSVg9zePf
