### PR TITLE
ci: keep push and pull_request runs of the same commit in separate concurrency groups

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ on:
 # Dedup the push+PR double-fire (see opensnes_build.yml for the rationale):
 # push and PR of the same branch head share a group, newer cancels older.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/opensnes_build.yml
+++ b/.github/workflows/opensnes_build.yml
@@ -23,7 +23,7 @@ on:
 # cancelled too. Safe: neither main nor develop is a protected branch with
 # required checks. Release tags are handled by release.yml (unique per tag).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 # ------------------------------------ #


### PR DESCRIPTION
A push to develop that also updates a develop → main PR fires both
workflows twice — once per event — with the same head ref, so the group
`<workflow>-develop` made the pull_request run cancel the push run. The
cancelled push run then showed as a failed check on the release PR, and
the v0.40.0 and v0.41.0 releases each needed a manual re-run before the
PR read as mergeable. The group now includes github.event_name; the
cancel-in-progress behaviour within one event is unchanged.

https://claude.ai/code/session_01SaBKev4cAfdNKbSVg9zePf